### PR TITLE
Add Galileo Wrapper

### DIFF
--- a/geofm_src/configs/dataset/base_dataset.yaml
+++ b/geofm_src/configs/dataset/base_dataset.yaml
@@ -11,3 +11,4 @@ subset:
   train: -1
   val: -1
   test: -1
+input_key: null

--- a/geofm_src/configs/dataset/geobench_eurosat_10b.yaml
+++ b/geofm_src/configs/dataset/geobench_eurosat_10b.yaml
@@ -1,0 +1,21 @@
+defaults:
+  - geobench
+  - s2_l1c
+
+benchmark_name: classification_v1.0
+dataset_name: m-eurosat
+task: classification
+num_classes: 10
+multilabel: false
+
+band_names:
+  - "02 - Blue"
+  - "03 - Green"
+  - "04 - Red"
+  - "05 - Vegetation Red Edge"
+  - "06 - Vegetation Red Edge"
+  - "07 - Vegetation Red Edge"
+  - "08 - NIR"
+  - "08A - Vegetation Red Edge"
+  - "11 - SWIR"
+  - "12 - SWIR"

--- a/geofm_src/configs/model/galileo.yaml
+++ b/geofm_src/configs/model/galileo.yaml
@@ -1,0 +1,3 @@
+model_type: galileo
+embed_dim: 768
+image_resolution: 224

--- a/geofm_src/factory.py
+++ b/geofm_src/factory.py
@@ -10,7 +10,8 @@ from geofm_src.foundation_models import (
     SatMAEModel,
     AnySatModel,
     SenPaMAEModel,
-    StealthModel
+    GalileoModel,
+    StealthModel,
 )
 from geofm_src.datasets.geobench_wrapper import GeoBenchDataset
 from geofm_src.datasets.resisc_wrapper import Resics45Dataset
@@ -29,7 +30,7 @@ model_registry = {
     "anysat": AnySatModel,
     "senpamae": SenPaMAEModel,
     "stealth": StealthModel,
-
+    "galileo": GalileoModel,
     "satmae": SatMAEModel,
     "scalemae": ScaleMAEModel,
     "gfm": GFMModel,
@@ -54,7 +55,7 @@ def create_dataset(config_data):
     dataset_class = dataset_registry.get(dataset_type)
     if dataset_class is None:
         raise ValueError(f"Dataset type '{dataset_type}' not found.")
-    
+
     dataset = dataset_class(config_data)
 
     return dataset.create_dataset()
@@ -64,8 +65,10 @@ def create_model(args, model_config, dataset_config=None):
     model_name = model_config.model_type
     model_class = model_registry.get(model_name)
     if model_class is None:
-        if model_name == 'stealth':
-            raise ImportError("Stealth model requires the stealth_wrapper to be available")
+        if model_name == "stealth":
+            raise ImportError(
+                "Stealth model requires the stealth_wrapper to be available"
+            )
         raise ValueError(f"Model type '{model_name}' not found.")
 
     model = model_class(args, model_config, dataset_config)

--- a/geofm_src/foundation_models/__init__.py
+++ b/geofm_src/foundation_models/__init__.py
@@ -9,7 +9,23 @@ from .satmae_wrapper import SatMAEModel
 from .anysat_wrapper import AnySatModel  # type: ignore
 from .senpamae_wrapper import SenPaMAEModel
 from .base import LinearHead
+from .galileo_wrapper import GalileoModel
 try:
     from .stealth_wrapper import StealthModel
 except ImportError:
     StealthModel = None
+
+__all__ = (
+    "CromaModel",
+    "ScaleMAEModel",
+    "GFMModel",
+    "DinoV2Model",
+    "SoftConModel",
+    "DofaModel",
+    "SatMAEModel",
+    "AnySatModel",
+    "SenPaMAEModel",
+    "LinearHead",
+    "GalileoModel",
+    "StealthModel"
+)

--- a/geofm_src/foundation_models/galileo/augmentation.py
+++ b/geofm_src/foundation_models/galileo/augmentation.py
@@ -1,0 +1,95 @@
+import random
+from typing import Dict, Tuple
+
+import torch
+import torchvision.transforms.v2.functional as F
+from einops import rearrange
+
+
+class FlipAndRotateSpace(object):
+    """
+    For now, lets have no parameters
+    Choose 1 of 8 transformations and apply it to space_time_x and space_x
+    """
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+        self.transformations = [
+            self.no_transform,  # No transformation
+            self.rotate_90,  # 90-degree rotation
+            self.rotate_180,  # 180-degree rotation
+            self.rotate_270,  # 270-degree rotation
+            self.hflip,  # Horizontal flip
+            self.vflip,  # Vertical flip
+            self.hflip_rotate_90,  # Horizontal flip of 90-degree rotated image
+            self.vflip_rotate_90,  # Vertical flip of 90-degree rotated image
+        ]
+
+    def no_transform(self, x):
+        return x
+
+    def rotate_90(self, x):
+        return F.rotate(x, 90)
+
+    def rotate_180(self, x):
+        return F.rotate(x, 180)
+
+    def rotate_270(self, x):
+        return F.rotate(x, 270)
+
+    def hflip(self, x):
+        return F.hflip(x)
+
+    def vflip(self, x):
+        return F.vflip(x)
+
+    def hflip_rotate_90(self, x):
+        return F.hflip(F.rotate(x, 90))
+
+    def vflip_rotate_90(self, x):
+        return F.vflip(F.rotate(x, 90))
+
+    def apply(
+        self,
+        space_time_x: torch.Tensor,
+        space_x: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if not self.enabled:
+            return space_time_x, space_x
+
+        space_time_x = rearrange(
+            space_time_x.float(), "b h w t c -> b t c h w"
+        )  # rearrange for transforms
+        space_x = rearrange(
+            space_x.float(), "b h w c -> b c h w"
+        )  # rearrange for transforms
+
+        transformation = random.choice(self.transformations)
+
+        space_time_x = rearrange(
+            transformation(space_time_x), "b t c h w -> b h w t c"
+        )  # rearrange back
+        space_x = rearrange(
+            transformation(space_x), "b c h w -> b h w c"
+        )  # rearrange back
+
+        return space_time_x.half(), space_x.half()
+
+
+class Augmentation(object):
+    def __init__(self, aug_config: Dict):
+        self.flip_and_rotate = FlipAndRotateSpace(
+            enabled=aug_config.get("flip+rotate", False)
+        )
+
+    def apply(
+        self,
+        space_time_x: torch.Tensor,
+        space_x: torch.Tensor,
+        time_x: torch.Tensor,
+        static_x: torch.Tensor,
+        months: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        space_time_x, space_x = self.flip_and_rotate.apply(space_time_x, space_x)
+
+        return space_time_x, space_x, time_x, static_x, months

--- a/geofm_src/foundation_models/galileo/collate_fns.py
+++ b/geofm_src/foundation_models/galileo/collate_fns.py
@@ -1,0 +1,234 @@
+from typing import List, NamedTuple, Optional, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import default_collate
+
+from .masking import (
+    MASKING_MODES,
+    MaskingFunctions,
+    batch_subset_mask_galileo,
+)
+
+
+class CollateFnOutput(NamedTuple):
+    s_t_x: torch.Tensor
+    sp_x: torch.Tensor
+    t_x: torch.Tensor
+    st_x: torch.Tensor
+    s_t_m: torch.Tensor
+    sp_m: torch.Tensor
+    t_m: torch.Tensor
+    st_m: torch.Tensor
+    months: torch.Tensor
+    patch_size: float
+
+
+def collated_batch_to_output(
+    s_t_x: torch.Tensor,
+    sp_x: torch.Tensor,
+    t_x: torch.Tensor,
+    st_x: torch.Tensor,
+    months: torch.Tensor,
+    patch_sizes,
+    shape_time_combinations,
+    encode_ratio,
+    decode_ratio,
+    masking_function: MaskingFunctions,
+    augmentation_strategies=None,
+    fixed_patch_size=None,
+    fixed_space_time_combination=None,
+    masking_probabilities=None,
+    max_unmasking_channels=4,
+    unmasking_channels_combo: str = "shapes",
+    ignore_band_groups: Optional[List[str]] = None,
+) -> CollateFnOutput:
+    if fixed_patch_size is not None:
+        patch_size = fixed_patch_size
+    else:
+        # randomly sample a patch size, and a corresponding image size
+        patch_size = np.random.choice(patch_sizes)
+
+    if fixed_space_time_combination is not None:
+        space_time_combination = fixed_space_time_combination
+    else:
+        space_time_combination = np.random.choice(shape_time_combinations)
+        spatial_patches_per_dim = space_time_combination["size"]
+        if int(spatial_patches_per_dim * patch_size) > s_t_x.shape[1]:
+            spatial_patches_per_dim = int(s_t_x.shape[1] / patch_size)
+
+    timesteps = space_time_combination["timesteps"]
+
+    image_size = patch_size * spatial_patches_per_dim
+    if masking_probabilities is None:
+        masking_probabilities = [1] * len(MASKING_MODES)
+
+    # randomly select a masking strategy
+    s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m, months = batch_subset_mask_galileo(
+        s_t_x,
+        sp_x,
+        t_x,
+        st_x,
+        months,
+        encode_ratio=encode_ratio,
+        patch_size=patch_size,
+        image_size=image_size,
+        num_timesteps=timesteps,
+        decode_ratio=decode_ratio,
+        augmentation_strategies=augmentation_strategies,
+        masking_probabilities=masking_probabilities,
+        masking_function=masking_function,
+        max_unmasking_channels=max_unmasking_channels,
+        unmasking_channels_combo=unmasking_channels_combo,
+        ignore_band_groups=ignore_band_groups,
+    )
+
+    return CollateFnOutput(
+        s_t_x,
+        sp_x,
+        t_x,
+        st_x,
+        s_t_m,
+        sp_m,
+        t_m,
+        st_m,
+        months,
+        patch_size,
+    )
+
+
+@torch.no_grad()
+def galileo_collate_fn(
+    batch,
+    patch_sizes,
+    shape_time_combinations,
+    st_encode_ratio=None,
+    st_decode_ratio=None,
+    random_encode_ratio=None,
+    random_decode_ratio=None,
+    augmentation_strategies=None,
+    fixed_patch_size=None,
+    fixed_space_time_combination=None,
+    masking_probabilities=None,
+    max_unmasking_channels=4,
+    random_masking: str = "None",
+    unmasking_channels_combo: str = "shapes",
+    ignore_band_groups: Optional[List[str]] = None,
+) -> Tuple[CollateFnOutput, CollateFnOutput, CollateFnOutput, CollateFnOutput]:
+    s_t_x, sp_x, t_x, st_x, months = default_collate(batch)
+
+    input_args = {
+        "s_t_x": s_t_x,
+        "sp_x": sp_x,
+        "t_x": t_x,
+        "st_x": st_x,
+        "months": months,
+        "patch_sizes": patch_sizes,
+        "augmentation_strategies": augmentation_strategies,
+        "fixed_patch_size": fixed_patch_size,
+        "fixed_space_time_combination": fixed_space_time_combination,
+        "masking_probabilities": masking_probabilities,
+        "shape_time_combinations": shape_time_combinations,
+        "max_unmasking_channels": max_unmasking_channels,
+        "unmasking_channels_combo": unmasking_channels_combo,
+        "ignore_band_groups": ignore_band_groups,
+    }
+    if random_masking == "none":
+        if st_encode_ratio is None:
+            raise ValueError("st_encode_ratio can't be None for random_masking='none'")
+        if st_decode_ratio is None:
+            raise ValueError("st_decode_ratio can't be None for random_masking='none'")
+        input_args.update(
+            {"encode_ratio": st_encode_ratio, "decode_ratio": st_decode_ratio}
+        )
+        return (
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.TIME,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.SPACE,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.TIME,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.SPACE,
+            ),
+        )
+    elif random_masking == "half":
+        if st_encode_ratio is None:
+            raise ValueError("st_encode_ratio can't be None for random_masking='half'")
+        if st_decode_ratio is None:
+            raise ValueError("st_decode_ratio can't be None for random_masking='half'")
+        if random_encode_ratio is None:
+            raise ValueError(
+                "random_encode_ratio can't be None for random_masking='half'"
+            )
+        if random_decode_ratio is None:
+            raise ValueError(
+                "random_decode_ratio can't be None for random_masking='half'"
+            )
+        return (
+            collated_batch_to_output(
+                **input_args,
+                encode_ratio=st_encode_ratio,
+                decode_ratio=st_decode_ratio,
+                masking_function=MaskingFunctions.TIME,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                encode_ratio=st_encode_ratio,
+                decode_ratio=st_decode_ratio,
+                masking_function=MaskingFunctions.SPACE,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                encode_ratio=random_encode_ratio,
+                decode_ratio=random_decode_ratio,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                encode_ratio=random_encode_ratio,
+                decode_ratio=random_decode_ratio,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+        )
+    elif random_masking == "full":
+        if random_encode_ratio is None:
+            raise ValueError(
+                "random_encode_ratio can't be None for random_masking='full'"
+            )
+        if random_decode_ratio is None:
+            raise ValueError(
+                "random_decode_ratio can't be None for random_masking='full'"
+            )
+        input_args.update(
+            {"encode_ratio": random_encode_ratio, "decode_ratio": random_decode_ratio}
+        )
+        return (
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+            collated_batch_to_output(
+                **input_args,
+                masking_function=MaskingFunctions.RANDOM,
+            ),
+        )
+    else:
+        raise ValueError(
+            f"Expected random_masking to be (none, half full), got {random_masking}"
+        )

--- a/geofm_src/foundation_models/galileo/masking.py
+++ b/geofm_src/foundation_models/galileo/masking.py
@@ -1,0 +1,855 @@
+import random
+from collections import OrderedDict
+from enum import Enum
+from itertools import chain, combinations, product
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
+
+import numpy as np
+import torch
+from einops import rearrange, repeat
+
+from .util import (
+    SPACE_BAND_GROUPS_IDX,
+    SPACE_TIME_BANDS_GROUPS_IDX,
+    STATIC_BAND_GROUPS_IDX,
+    TIME_BAND_GROUPS_IDX,
+)
+from .augmentation import Augmentation
+
+# This is to allow a quick expansion of the mask from
+# group-channel space into real-channel space
+SPACE_TIME_BAND_EXPANSION = torch.tensor(
+    [len(x) for x in SPACE_TIME_BANDS_GROUPS_IDX.values()]
+).long()
+SPACE_BAND_EXPANSION = torch.tensor(
+    [len(x) for x in SPACE_BAND_GROUPS_IDX.values()]
+).long()
+TIME_BAND_EXPANSION = torch.tensor(
+    [len(x) for x in TIME_BAND_GROUPS_IDX.values()]
+).long()
+STATIC_BAND_EXPANSION = torch.tensor(
+    [len(x) for x in STATIC_BAND_GROUPS_IDX.values()]
+).long()
+
+
+STR2DICT = OrderedDict(
+    {
+        "space_time": SPACE_TIME_BANDS_GROUPS_IDX,
+        "space": SPACE_BAND_GROUPS_IDX,
+        "time": TIME_BAND_GROUPS_IDX,
+        "static": STATIC_BAND_GROUPS_IDX,
+    }
+)
+
+REVERSED_STR2DICT = {}
+for key, values in STR2DICT.items():
+    for v in values:
+        REVERSED_STR2DICT[v] = key
+
+SHAPES = list(STR2DICT.keys())
+MASKING_MODES: List[Tuple[str, str]] = [
+    ("space", "SRTM"),
+    ("space", "DW"),
+    ("space", "WC"),
+    ("space_time", "NDVI"),
+    ("space_time", "S1"),
+    ("space_time", "S2_RGB"),
+    ("space_time", "S2_SWIR"),
+    ("space_time", "S2_Red_Edge"),
+    ("space_time", "S2_NIR_10m"),
+    ("space_time", "S2_NIR_20m"),
+    ("time", "ERA5"),
+    ("time", "TC"),
+    ("time", "VIIRS"),
+    ("static", "LS"),
+    ("static", "location"),
+    ("static", "DW_static"),
+    ("static", "WC_static"),
+]
+
+UNMASKING_CHANNEL_GROUPS: List[Tuple[str, str]] = MASKING_MODES
+
+MAX_MASKING_STRATEGIES = 6
+NUM_RECON_OBJS = 2
+
+
+def generate_combinations():
+    all_combinations = []
+    for r in range(1, 5):
+        shape_combos = combinations(SHAPES, r)
+
+        for shape_combo in shape_combos:
+            mode_lists = [STR2DICT[shape] for shape in shape_combo]
+            mode_combos = product(*mode_lists)
+            for mode_combo in mode_combos:
+                all_combinations.append([(REVERSED_STR2DICT[x], x) for x in mode_combo])
+
+    return all_combinations
+
+
+def powerset(iterable):
+    "powerset([1,2,3]) → (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    s = list(iterable)
+    return_list = list(
+        chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+    )
+    return [item for item in return_list if len(item) > 0]
+
+
+# Generate all 639 combinations
+ALL_MASKING_COMBINATIONS_SHAPES = generate_combinations()
+ALL_MASKING_COMBINATIONS = powerset(MASKING_MODES)
+
+
+class MaskingFunctions(Enum):
+    SPACE = 1
+    TIME = 0
+    RANDOM = 2
+
+
+def return_masked_unmasked_bands(
+    bands: List[str], band_groups: Dict[str, List]
+) -> Tuple[List[int], List[int]]:
+    def in_masked_bands(x):
+        for b in bands:
+            if b in x:
+                return True
+        return False
+
+    return [
+        idx for idx, val in enumerate(band_groups.keys()) if in_masked_bands(val)
+    ], [idx for idx, val in enumerate(band_groups.keys()) if not in_masked_bands(val)]
+
+
+class MaskedOutput(NamedTuple):
+    """
+    A mask can take 3 values:
+    0: seen by the encoder (i.e. makes the key and value tokens in the decoder)
+    1: not seen by the encoder, and ignored by the decoder
+    2: not seen by the encoder, and processed by the decoder (the decoder's query values)
+    """
+
+    space_time_x: torch.Tensor  # [B, H, W, T, len(SPACE_TIME_BANDS)]
+    space_x: torch.Tensor  # [B, H, W, len(SPACE_BANDS)]
+    time_x: torch.Tensor  # [B, T, len(TIME_BANDS)]
+    static_x: torch.Tensor  # [B, len(STATIC_BANDS)]
+    space_time_mask: torch.Tensor  # [B, H, W, T, len(SPACE_TIME_BANDS_GROUPS_IDX)]
+    space_mask: torch.Tensor  # [B, H, W, len(SPACE_BAND_GROUPS_IDX)]
+    time_mask: torch.Tensor  # [B, T, len(TIME_BAND_GROUPS_IDX)]
+    static_mask: torch.Tensor  # [B, len(STATIC_BAND_GROUPS_IDX)]
+    months: torch.Tensor  # [B, T]
+
+
+def weighted_sample_without_replacement(population, weights, k, rng=random):
+    if len(population) != len(weights):
+        raise ValueError("Population and weights must have the same length")
+
+    non_zero_indices = [i for i, w in enumerate(weights) if w > 0]
+    if len(non_zero_indices) < k:
+        raise ValueError("Not enough non-zero weights to sample k items")
+
+    non_zero_population = [population[i] for i in non_zero_indices]
+    non_zero_weights = [weights[i] for i in non_zero_indices]
+
+    v = [rng.random() ** (1 / w) for w in non_zero_weights]
+    order = sorted(range(len(non_zero_population)), key=lambda i: v[i])
+    return [non_zero_population[i] for i in order[-k:]]
+
+
+def check_modes_for_conflicts(
+    modes: List[Tuple[str, str]], unmasking_modes: List[Tuple[str, str]]
+) -> Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]:
+    output_modes: List[Tuple[str, str]] = []
+    for mode in modes:
+        assert mode in MASKING_MODES
+        if mode in unmasking_modes:
+            if len(unmasking_modes) == 1:
+                # don't remove any more from the unmasking modes
+                continue
+            elif len(output_modes) == 0:
+                output_modes.append(mode)
+                unmasking_modes.remove(mode)
+            else:
+                # neither modes or unmasking_modes are bottlenecked;
+                # randomly select which one to remove
+                if random.random() <= 0.5:
+                    output_modes.append(mode)
+                    unmasking_modes.remove(mode)
+        else:
+            output_modes.append(mode)
+    assert len(output_modes) >= 1
+    assert len(unmasking_modes) >= 1
+    return output_modes, unmasking_modes
+
+
+def check_mode_and_return_channels(unmasking_modes: List[Tuple[str, str]]):
+    outputs = []
+    for data_type in STR2DICT.keys():
+        relevant_bands = [x[1] for x in unmasking_modes if x[0] == data_type]
+        if len(relevant_bands) > 0:
+            outputs.append(
+                return_masked_unmasked_bands(relevant_bands, STR2DICT[data_type])
+            )
+        else:
+            outputs.append(([], []))
+    return outputs
+
+
+def round_school(x: float) -> float:
+    i, f = divmod(x, 1)
+    return int(i + ((f >= 0.5) if (x > 0) else (f > 0.5)))
+
+
+def filter_unmasking_mode_candidates(
+    unmasking_mode_candidates, ignore_band_groups: Optional[List[str]]
+):
+    def check_if_overlap(candidate, ignore_band_groups):
+        for channel_group in candidate:
+            if channel_group[1] in ignore_band_groups:
+                return True
+        return False
+
+    if ignore_band_groups is None:
+        return unmasking_mode_candidates
+    output_candidates = []
+    for candidate in unmasking_mode_candidates:
+        if check_if_overlap(candidate, ignore_band_groups):
+            continue
+        else:
+            output_candidates.append(candidate)
+    return output_candidates
+
+
+def batch_subset_mask_galileo(
+    s_t_x: torch.Tensor,
+    sp_x: torch.Tensor,
+    t_x: torch.Tensor,
+    st_x: torch.Tensor,
+    months: torch.Tensor,
+    encode_ratio: float,
+    decode_ratio: float,
+    patch_size: int,
+    image_size: int,
+    num_timesteps: int,
+    augmentation_strategies: Optional[Dict],
+    masking_probabilities: List[float],
+    masking_function: MaskingFunctions,
+    max_unmasking_channels: int,
+    unmasking_channels_combo: str = "shapes",
+    ignore_band_groups: Optional[List[str]] = None,
+) -> MaskedOutput:
+    assert len(masking_probabilities) == len(MASKING_MODES)
+
+    if masking_function.value < 2:
+        f: Callable = (
+            batch_mask_space if masking_function.value == 1 else batch_mask_time
+        )
+        num_masking_modes = random.choice(list(range(2, MAX_MASKING_STRATEGIES + 1)))
+        if ignore_band_groups is not None:
+            masking_modes, kept_masking_probs = zip(
+                *(
+                    (m, p)
+                    for m, p in zip(MASKING_MODES, masking_probabilities)
+                    if m[1] not in ignore_band_groups
+                )
+            )
+        else:
+            masking_modes, kept_masking_probs = MASKING_MODES, masking_probabilities  # type: ignore
+        masking_modes = weighted_sample_without_replacement(
+            masking_modes, weights=kept_masking_probs, k=num_masking_modes
+        )  # type: ignore
+
+        # isolate the unmasking candidates which (1) have the right number of channels and
+        # (b) don't intersect with the masking_modes
+        if unmasking_channels_combo == "shapes":
+            unmasking_mode_candidates = [
+                x
+                for x in filter_unmasking_mode_candidates(
+                    ALL_MASKING_COMBINATIONS_SHAPES, ignore_band_groups
+                )
+                if (
+                    (len(x) <= max_unmasking_channels)
+                    and (len(set(x) & set(masking_modes)) == 0)
+                )
+            ]
+        elif unmasking_channels_combo == "all":
+            unmasking_mode_candidates = [
+                x
+                for x in filter_unmasking_mode_candidates(
+                    ALL_MASKING_COMBINATIONS, ignore_band_groups
+                )
+                if (
+                    (len(x) <= max_unmasking_channels)
+                    and (len(set(x) & set(masking_modes)) == 0)
+                )
+            ]
+        else:
+            raise ValueError(
+                "Expected unmasking_channels_combo to be "
+                f"'shapes' or 'all', got {unmasking_channels_combo}"
+            )
+        unmasking_modes = random.choice(unmasking_mode_candidates)
+
+        masking_modes, unmasking_modes = check_modes_for_conflicts(
+            masking_modes, unmasking_modes
+        )  # type: ignore
+        masked_output = f(
+            *subset_and_augment_batch_of_images(
+                s_t_x,
+                sp_x,
+                t_x,
+                st_x,
+                months,
+                size=image_size,
+                num_timesteps=num_timesteps,
+                augmentation_strategies=augmentation_strategies,
+            ),
+            encode_ratio=encode_ratio,
+            decode_ratio=decode_ratio,
+            patch_size=patch_size,
+            mode=masking_modes,
+            decoder_mode=unmasking_modes,
+        )
+
+    elif masking_function.value == 2:
+        # 2 is random
+        masked_output = batch_mask_random(
+            *subset_and_augment_batch_of_images(
+                s_t_x,
+                sp_x,
+                t_x,
+                st_x,
+                months,
+                size=image_size,
+                num_timesteps=num_timesteps,
+                augmentation_strategies=augmentation_strategies,
+            ),
+            encode_ratio=encode_ratio,
+            decode_ratio=decode_ratio,
+            patch_size=patch_size,
+            ignore_band_groups=ignore_band_groups,
+        )
+
+    else:
+        raise AssertionError(f"Unexpected strategy {masking_function}")
+
+    return masked_output
+
+
+def subset_and_augment_batch_of_images(
+    space_time_x: torch.Tensor,
+    space_x: torch.Tensor,
+    time_x: torch.Tensor,
+    static_x: torch.Tensor,
+    months: torch.Tensor,
+    size: int,
+    num_timesteps: int,
+    augmentation_strategies: Optional[Dict],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert (space_time_x.shape[1] == space_x.shape[1]) & (
+        space_time_x.shape[2] == space_x.shape[2]
+    )
+    assert time_x.shape[1] == space_time_x.shape[3] == months.shape[1]
+    possible_h = space_time_x.shape[1] - size
+    possible_w = space_time_x.shape[2] - size
+    possible_t = space_time_x.shape[3] - num_timesteps
+    assert (possible_h >= 0) & (possible_w >= 0) & (possible_t >= 0)
+
+    if possible_h > 0:
+        start_h = np.random.choice(possible_h)
+    else:
+        start_h = possible_h
+
+    if possible_w > 0:
+        start_w = np.random.choice(possible_w)
+    else:
+        start_w = possible_w
+
+    if possible_t > 0:
+        start_t = np.random.choice(possible_t)
+    else:
+        start_t = possible_t
+
+    # do augmentations, if enabled
+    space_time_x = space_time_x[
+        :,
+        start_h : start_h + size,
+        start_w : start_w + size,
+        start_t : start_t + num_timesteps,
+    ]
+    space_x = space_x[:, start_h : start_h + size, start_w : start_w + size]
+    time_x = time_x[:, start_t : start_t + num_timesteps]
+    months = months[:, start_t : start_t + num_timesteps]
+
+    if augmentation_strategies is not None:
+        return Augmentation(augmentation_strategies).apply(
+            space_time_x, space_x, time_x, static_x, months
+        )
+    return space_time_x, space_x, time_x, static_x, months
+
+
+def _random_mask_for_b(
+    b: int, device: torch.device, encode_ratio: float, decode_ratio: float
+) -> torch.Tensor:
+    mask = torch.rand(b, device=device)
+    mask[mask >= (1 - encode_ratio)] = 0
+    mask[mask <= decode_ratio] = 2
+    # all the rest is ignored by both the encoder and decoder
+    mask[(mask != 0) | (mask != 2)] = 1
+    return mask
+
+
+def batch_mask_time(
+    space_time_x: torch.Tensor,
+    space_x: torch.Tensor,
+    time_x: torch.Tensor,
+    static_x: torch.Tensor,
+    months: torch.Tensor,
+    encode_ratio: float,
+    decode_ratio: float,
+    patch_size: int,
+    decoder_mode: List[Tuple[str, str]],
+    mode: List[Tuple[str, str]],
+):
+    """
+    Masks out blocks of hxwx1xBAND_GROUPs.
+    e.g. if mask_ratio=0.25, then 1/4 of the timeteps
+    (and the static channel groups, with 1/4 probability) will be masked out
+
+    Operates over batches where each item in the batch has independently masked timesteps
+    """
+    b, h, w, t, _ = space_time_x.shape
+    assert t >= 3
+
+    bands_to_encode = check_mode_and_return_channels(mode)
+    bands_to_decode = check_mode_and_return_channels(decoder_mode)
+    # if there is only a single timestep, decode it
+    num_timesteps_to_decode = max(int(t * decode_ratio), 1)
+    num_timesteps_to_encode = max(int(t * encode_ratio), 1)
+    # we do this as a numpy array to take advantage of
+    # numpy's permuted function
+    flat_timesteps = np.concatenate(
+        (
+            np.ones(
+                t - (num_timesteps_to_decode + num_timesteps_to_encode), dtype=np.int_
+            ),
+            np.ones(num_timesteps_to_decode, dtype=np.int_) * 2,
+            np.zeros(num_timesteps_to_encode, dtype=np.int_),
+        )
+    )
+    b_flat_timesteps = repeat(flat_timesteps, "t -> b t", b=b)
+    # hopefully this will allow for reproducibility, since random is seeded
+    rng = np.random.default_rng(random.randint(0, 100))
+    b_flat_timesteps_t = torch.from_numpy(rng.permuted(b_flat_timesteps, axis=1)).to(
+        space_time_x.device
+    )
+    space_time_mask = repeat(
+        b_flat_timesteps_t,
+        "b t-> b h w t c_g",
+        h=h,
+        w=w,
+        c_g=len(SPACE_TIME_BANDS_GROUPS_IDX),
+    ).clone()
+    # make the mask as if bands_to_mask and bands_to_decode both = None
+    time_mask = repeat(
+        b_flat_timesteps_t,
+        "b t-> b t c_g",
+        c_g=len(TIME_BAND_GROUPS_IDX),
+    ).clone()
+    space_mask = _random_mask_for_b(b, space_x.device, encode_ratio, decode_ratio)
+    space_mask = repeat(
+        space_mask, "b -> b h w c_g", h=h, w=w, c_g=len(SPACE_BAND_GROUPS_IDX)
+    ).clone()
+    static_mask = _random_mask_for_b(b, static_x.device, encode_ratio, decode_ratio)
+    static_mask = repeat(
+        static_mask, "b -> b c_g", c_g=len(STATIC_BAND_GROUPS_IDX)
+    ).clone()
+    if max([len(x[0]) for x in bands_to_encode]) >= 1:  # encoder mode != random
+        # for static in time data,
+        # ignore all previous calculations about what should be encoded
+        static_mask = torch.clamp(static_mask, min=1)
+        space_mask = torch.clamp(space_mask, min=1)
+
+        s_t_e, s_e, t_e, st_e = bands_to_encode
+
+        if len(s_t_e[0]) > 0:
+            # there are space time bands to decode
+            s_t_bands_to_mask = s_t_e[1]
+            space_time_mask[:, :, :, :, s_t_bands_to_mask] = torch.clamp(
+                space_time_mask[:, :, :, :, s_t_bands_to_mask], min=1
+            )
+        else:
+            space_time_mask = torch.clamp(space_time_mask, min=1)
+
+        if len(s_e[0]) > 0:
+            s_bands_to_encode = s_e[0]
+            # there are space bands to mask
+            space_mask[:, :, :, s_bands_to_encode] = 0
+
+        if len(t_e[0]) > 0:
+            t_bands_to_mask = t_e[1]
+            time_mask[:, :, t_bands_to_mask] = torch.clamp(
+                time_mask[:, :, t_bands_to_mask], min=1
+            )
+        else:
+            time_mask = torch.clamp(time_mask, min=1)
+
+        if len(st_e[0]) > 0:
+            st_bands_to_encode = st_e[0]
+            static_mask[:, st_bands_to_encode] = 0
+
+    if max([len(x[0]) for x in bands_to_decode]) >= 1:  # decoder mode != random
+        # for static in time data,
+        # ignore all previous calculations about what should be decoded
+        static_mask = torch.clamp(static_mask, max=1)
+        space_mask = torch.clamp(space_mask, max=1)
+
+        s_t_d, s_d, t_d, st_d = bands_to_decode
+
+        if len(s_t_d[0]) > 0:
+            # there are space time bands to decode
+            s_t_bands_to_mask = s_t_d[1]
+            space_time_mask[:, :, :, :, s_t_bands_to_mask] = torch.clamp(
+                space_time_mask[:, :, :, :, s_t_bands_to_mask], max=1
+            )
+        else:
+            space_time_mask = torch.clamp(space_time_mask, max=1)
+
+        if len(s_d[0]) > 0:
+            s_bands_to_decode = s_d[0]
+            # there are space bands to mask
+            space_mask[:, :, :, s_bands_to_decode] = 2
+
+        if len(t_d[0]) > 0:
+            t_bands_to_mask = t_d[1]
+            time_mask[:, :, t_bands_to_mask] = torch.clamp(
+                time_mask[:, :, t_bands_to_mask], max=1
+            )
+        else:
+            time_mask = torch.clamp(time_mask, max=1)
+
+        if len(st_d[0]) > 0:
+            st_bands_to_decode = st_d[0]
+            static_mask[:, st_bands_to_decode] = 2
+
+    return MaskedOutput(
+        space_time_x.clone(),
+        space_x.clone(),
+        time_x.clone(),
+        static_x.clone(),
+        space_time_mask,
+        space_mask,
+        time_mask,
+        static_mask,
+        months,
+    )
+
+
+def batch_mask_space(
+    space_time_x: torch.Tensor,
+    space_x: torch.Tensor,
+    time_x: torch.Tensor,
+    static_x: torch.Tensor,
+    months: torch.Tensor,
+    patch_size: int,
+    encode_ratio: float,
+    decode_ratio: float,
+    mode: List[Tuple[str, str]],
+    decoder_mode: List[Tuple[str, str]],
+):
+    """
+    Masks out patches (blocks of of pxpxtxBAND_GROUPs).
+    e.g. if mask_ratio=0.25, h = w = 8 and p=2, then a mask might be:
+    [0 0 1 1]
+    [0 0 1 1]
+    [0 0 0 0]
+    [0 0 0 0]
+    repeated over all dynamic timesteps + channel groups and static channel groups
+    Operates over batches where each item in the batch is independently masked
+    """
+    bands_to_encode = check_mode_and_return_channels(mode)
+    bands_to_decode = check_mode_and_return_channels(decoder_mode)
+    b, h, w, t, _ = space_time_x.shape
+    assert (h % patch_size == 0) and (w % patch_size == 0)
+    h_p = int(h / patch_size)
+    w_p = int(w / patch_size)
+    total_patches = h_p * w_p
+    num_patches_to_encode = int(total_patches * encode_ratio)
+    num_patches_to_decode = int(total_patches * decode_ratio)
+    # we do this as a numpy array to take advantage of
+    # numpy's permuted function
+    flat_patches = np.concatenate(
+        (
+            np.ones(
+                total_patches - (num_patches_to_encode + num_patches_to_decode),
+                dtype=np.int_,
+            ),
+            np.ones(num_patches_to_decode, dtype=np.int_) * 2,
+            np.zeros(num_patches_to_encode, dtype=np.int_),
+        )
+    )
+    b_flat_patches = repeat(flat_patches, "p -> b p", b=b)
+    # hopefully this will allow for reproducibility, since random is seeded
+    rng = np.random.default_rng(random.randint(0, 100))
+    b_flat_patches = rng.permuted(b_flat_patches, axis=1)
+    two_d_patch_mask = rearrange(b_flat_patches, "b (h w) -> b h w", h=h_p, w=w_p)
+    two_d_mask = np.repeat(
+        np.repeat(two_d_patch_mask, repeats=patch_size, axis=1),
+        repeats=patch_size,
+        axis=2,
+    )
+    space_time_mask = (
+        torch.from_numpy(
+            repeat(
+                two_d_mask,
+                "b h w -> b h w t c_g",
+                t=t,
+                c_g=len(SPACE_TIME_BANDS_GROUPS_IDX),
+            )
+        )
+        .clone()
+        .to(space_time_x.device)
+    )
+
+    space_mask = (
+        torch.from_numpy(
+            repeat(
+                two_d_mask,
+                "b h w -> b h w c_g",
+                c_g=len(SPACE_BAND_GROUPS_IDX),
+            )
+        )
+        .clone()
+        .to(space_x.device)
+    )
+    time_mask = _random_mask_for_b(b, time_x.device, encode_ratio, decode_ratio)
+    time_mask = repeat(
+        time_mask, "b -> b t c_g", t=t, c_g=len(TIME_BAND_GROUPS_IDX)
+    ).clone()
+    static_mask = _random_mask_for_b(b, static_x.device, encode_ratio, decode_ratio)
+    static_mask = repeat(
+        static_mask, "b -> b c_g", c_g=len(STATIC_BAND_GROUPS_IDX)
+    ).clone()
+
+    if max([len(x[0]) for x in bands_to_encode]) >= 1:  # encoder mode != random
+        # for static in space data,
+        # ignore all previous calculations about what should be encoded
+        static_mask = torch.clamp(static_mask, min=1)
+        time_mask = torch.clamp(time_mask, min=1)
+
+        s_t_e, s_e, t_e, st_e = bands_to_encode
+
+        if len(s_t_e[0]) > 0:
+            # there are space time bands to decode
+            s_t_bands_to_mask = s_t_e[1]
+            space_time_mask[:, :, :, :, s_t_bands_to_mask] = torch.clamp(
+                space_time_mask[:, :, :, :, s_t_bands_to_mask], min=1
+            )
+        else:
+            space_time_mask = torch.clamp(space_time_mask, min=1)
+
+        if len(s_e[0]) > 0:
+            s_bands_to_mask = s_e[1]
+            # there are space bands to mask
+            space_mask[:, :, :, s_bands_to_mask] = torch.clamp(
+                space_mask[:, :, :, s_bands_to_mask], min=1
+            )
+        else:
+            space_mask = torch.clamp(space_mask, min=1)
+
+        if len(t_e[0]) > 0:
+            t_bands_to_encode = t_e[0]
+            time_mask[:, :, t_bands_to_encode] = 0
+
+        if len(st_e[0]) > 0:
+            st_bands_to_encode = st_e[0]
+            static_mask[:, st_bands_to_encode] = 0
+
+    if max([len(x[0]) for x in bands_to_decode]) >= 1:  # decoder mode != random
+        # for static in space data,
+        # ignore all previous calculations about what should be decoded
+        static_mask = torch.clamp(static_mask, max=1)
+        time_mask = torch.clamp(time_mask, max=1)
+
+        s_t_d, s_d, t_d, st_d = bands_to_decode
+
+        if len(s_t_d[0]) > 0:
+            # there are space time bands to decode
+            s_t_bands_to_mask = s_t_d[1]
+            space_time_mask[:, :, :, :, s_t_bands_to_mask] = torch.clamp(
+                space_time_mask[:, :, :, :, s_t_bands_to_mask], max=1
+            )
+        else:
+            space_time_mask = torch.clamp(space_time_mask, max=1)
+
+        if len(s_d[0]) > 0:
+            s_bands_to_mask = s_d[1]
+            # there are space bands to mask
+            space_mask[:, :, :, s_bands_to_mask] = torch.clamp(
+                space_mask[:, :, :, s_bands_to_mask], max=1
+            )
+        else:
+            space_mask = torch.clamp(space_mask, max=1)
+
+        if len(t_d[0]) > 0:
+            t_bands_to_decode = t_d[0]
+            time_mask[:, :, t_bands_to_decode] = 2
+
+        if len(st_d[0]) > 0:
+            st_bands_to_decode = st_d[0]
+            static_mask[:, st_bands_to_decode] = 2
+
+    return MaskedOutput(
+        space_time_x.clone(),
+        space_x.clone(),
+        time_x.clone(),
+        static_x.clone(),
+        space_time_mask,
+        space_mask,
+        time_mask,
+        static_mask,
+        months,
+    )
+
+
+def batch_mask_random(
+    space_time_x: torch.Tensor,
+    space_x: torch.Tensor,
+    time_x: torch.Tensor,
+    static_x: torch.Tensor,
+    months: torch.Tensor,
+    encode_ratio: float,
+    decode_ratio: float,
+    patch_size: int,
+    ignore_band_groups: Optional[List[str]] = None,
+):
+    """
+    Masks out random tokens (blocks of of pxpx1x1).
+    e.g. if mask_ratio=0.25, h = w = 8 and p=2, then a mask (for one timestep)
+    and channel group) might be
+    [0 0 1 1]
+    [0 0 1 1]
+    [0 0 0 0]
+    [0 0 0 0]
+    Operates over batches where each item in the batch is independently masked
+    """
+
+    def indices_of_ignored(
+        band_groups: OrderedDict, ignore_band_groups: Optional[List]
+    ):
+        if ignore_band_groups is None:
+            return len(band_groups), []
+        else:
+            ignored_band_indices = []
+            for idx, (band, _) in enumerate(band_groups.items()):
+                if band in ignore_band_groups:
+                    ignored_band_indices.append(idx)
+            return len(band_groups) - len(ignored_band_indices), ignored_band_indices
+
+    b, h, w, t, _ = space_time_x.shape
+    c_s_t, c_s_t_ignore = indices_of_ignored(
+        SPACE_TIME_BANDS_GROUPS_IDX, ignore_band_groups
+    )
+    c_sp, c_sp_ignore = indices_of_ignored(SPACE_BAND_GROUPS_IDX, ignore_band_groups)
+    c_t, c_t_ignore = indices_of_ignored(TIME_BAND_GROUPS_IDX, ignore_band_groups)
+    c_st, c_st_ignore = indices_of_ignored(STATIC_BAND_GROUPS_IDX, ignore_band_groups)
+    assert (h % patch_size == 0) and (w % patch_size == 0)
+    h_p = int(h / patch_size)
+    w_p = int(w / patch_size)
+
+    num_space_time_tokens = h_p * w_p * t * c_s_t
+    num_space_tokens = h_p * w_p * c_sp
+    num_time_tokens = t * c_t
+    num_static_tokens = c_st
+
+    total_tokens = (
+        num_space_time_tokens + num_space_tokens + num_time_tokens + num_static_tokens
+    )
+    tokens_the_decoder_will_unmask = int(total_tokens * decode_ratio)
+    tokens_the_encoder_will_encode = int(total_tokens * encode_ratio)
+    # we do this as a numpy array to take advantage of
+    # numpy's permuted function
+    flat_tokens = np.concatenate(
+        (
+            np.ones(
+                total_tokens
+                - (tokens_the_encoder_will_encode + tokens_the_decoder_will_unmask),
+                dtype=np.int_,
+            ),
+            np.ones(tokens_the_decoder_will_unmask, dtype=np.int_) * 2,
+            np.zeros(
+                tokens_the_encoder_will_encode,
+                dtype=np.int_,
+            ),
+        )
+    )
+    b_flat_tokens = repeat(flat_tokens, "t -> b t", b=b)
+    # hopefully this will allow for reproducibility, since random is seeded
+    rng = np.random.default_rng(random.randint(0, 100))
+    b_flat_tokens = rng.permuted(b_flat_tokens, axis=1)
+
+    s_t_tokens = b_flat_tokens[:, :num_space_time_tokens]
+    s_t_tokens = rearrange(
+        s_t_tokens, "b (h w t c) -> b h w t c", h=h_p, w=w_p, t=t, c=c_s_t
+    )
+    for s_t_ignored_cg in c_s_t_ignore:
+        # make the empty array
+        ignored_mask = np.ones_like(s_t_tokens[:, :, :, :, 0])
+        s_t_tokens = np.insert(
+            s_t_tokens, obj=s_t_ignored_cg, values=ignored_mask, axis=-1
+        )
+    space_time_mask = torch.from_numpy(
+        np.repeat(
+            np.repeat(s_t_tokens, repeats=patch_size, axis=1),
+            repeats=patch_size,
+            axis=2,
+        )
+    ).to(space_time_x.device)
+
+    space_tokens = b_flat_tokens[
+        :, num_space_time_tokens : -(num_time_tokens + num_static_tokens)
+    ]
+    space_tokens = rearrange(space_tokens, "b (h w c) -> b h w c", h=h_p, w=w_p, c=c_sp)
+    for sp_ignored_cg in c_sp_ignore:
+        # make the empty array
+        ignored_mask = np.ones_like(space_tokens[:, :, :, 0])
+        space_tokens = np.insert(
+            space_tokens, obj=sp_ignored_cg, values=ignored_mask, axis=-1
+        )
+    space_mask = torch.from_numpy(
+        np.repeat(
+            np.repeat(space_tokens, repeats=patch_size, axis=1),
+            repeats=patch_size,
+            axis=2,
+        )
+    ).to(space_x.device)
+
+    time_tokens = b_flat_tokens[
+        :, -(num_time_tokens + num_static_tokens) : -num_static_tokens
+    ]
+    time_mask = rearrange(time_tokens, "b (t c) -> b t c", t=t, c=c_t)
+    for t_ignored_cg in c_t_ignore:
+        # make the empty array
+        ignored_mask = np.ones_like(time_mask[:, :, 0])
+        time_mask = np.insert(time_mask, obj=t_ignored_cg, values=ignored_mask, axis=-1)
+    time_mask_t = torch.from_numpy(time_mask).to(time_x.device)
+
+    static_tokens = b_flat_tokens[:, -num_static_tokens:]
+    for st_ignored_cg in c_st_ignore:
+        # make the empty array
+        ignored_mask = np.ones_like(static_tokens[:, 0])
+        static_tokens = np.insert(
+            static_tokens, obj=st_ignored_cg, values=ignored_mask, axis=-1
+        )
+    static_mask = torch.from_numpy(static_tokens).to(static_x.device)
+    return MaskedOutput(
+        space_time_x.clone(),
+        space_x.clone(),
+        time_x.clone(),
+        static_x.clone(),
+        space_time_mask,
+        space_mask,
+        time_mask_t,
+        static_mask,
+        months,
+    )

--- a/geofm_src/foundation_models/galileo/model.py
+++ b/geofm_src/foundation_models/galileo/model.py
@@ -1,0 +1,1527 @@
+# MIT License
+# Copyright (c) 2024 Presto Authors
+
+# https://github.com/nasaharvest/galileo/blob/main/single_file_galileo.py
+
+import collections.abc
+import itertools
+import json
+import math
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import OrderedDict as OrderedDictType
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange, repeat
+from torch import Tensor, vmap
+from torch.jit import Final
+
+# constants
+CONFIG_FILENAME = "config.json"
+ENCODER_FILENAME = "encoder.pt"
+BASE_GSD = 10
+
+# band information
+S1_BANDS = ["VV", "VH"]
+S2_BANDS = [
+    "B2",
+    "B3",
+    "B4",
+    "B5",
+    "B6",
+    "B7",
+    "B8",
+    "B8A",
+    "B11",
+    "B12",
+]
+ERA5_BANDS = ["temperature_2m", "total_precipitation_sum"]
+TC_BANDS = ["def", "soil", "aet"]
+VIIRS_BANDS = ["avg_rad"]
+SRTM_BANDS = ["elevation", "slope"]
+DW_BANDS = [
+    "DW_water",
+    "DW_trees",
+    "DW_grass",
+    "DW_flooded_vegetation",
+    "DW_crops",
+    "DW_shrub_and_scrub",
+    "DW_built",
+    "DW_bare",
+    "DW_snow_and_ice",
+]
+WC_BANDS = [
+    "WC_temporarycrops",
+    "WC_maize",
+    "WC_wintercereals",
+    "WC_springcereals",
+    "WC_irrigation",
+]
+STATIC_DW_BANDS = [f"{x}_static" for x in DW_BANDS]
+STATIC_WC_BANDS = [f"{x}_static" for x in WC_BANDS]
+
+LANDSCAN_BANDS = ["b1"]
+LOCATION_BANDS = ["x", "y", "z"]
+
+SPACE_TIME_BANDS = S1_BANDS + S2_BANDS + ["NDVI"]
+TIME_BANDS = ERA5_BANDS + TC_BANDS + VIIRS_BANDS
+SPACE_BANDS = SRTM_BANDS + DW_BANDS + WC_BANDS
+STATIC_BANDS = LANDSCAN_BANDS + LOCATION_BANDS + STATIC_DW_BANDS + STATIC_WC_BANDS
+
+
+SPACE_TIME_BANDS_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "S1": [SPACE_TIME_BANDS.index(b) for b in S1_BANDS],
+        "S2_RGB": [SPACE_TIME_BANDS.index(b) for b in ["B2", "B3", "B4"]],
+        "S2_Red_Edge": [SPACE_TIME_BANDS.index(b) for b in ["B5", "B6", "B7"]],
+        "S2_NIR_10m": [SPACE_TIME_BANDS.index(b) for b in ["B8"]],
+        "S2_NIR_20m": [SPACE_TIME_BANDS.index(b) for b in ["B8A"]],
+        "S2_SWIR": [SPACE_TIME_BANDS.index(b) for b in ["B11", "B12"]],
+        "NDVI": [SPACE_TIME_BANDS.index("NDVI")],
+    }
+)
+
+TIME_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "ERA5": [TIME_BANDS.index(b) for b in ERA5_BANDS],
+        "TC": [TIME_BANDS.index(b) for b in TC_BANDS],
+        "VIIRS": [TIME_BANDS.index(b) for b in VIIRS_BANDS],
+    }
+)
+
+SPACE_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "SRTM": [SPACE_BANDS.index(b) for b in SRTM_BANDS],
+        "DW": [SPACE_BANDS.index(b) for b in DW_BANDS],
+        "WC": [SPACE_BANDS.index(b) for b in WC_BANDS],
+    }
+)
+
+STATIC_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "LS": [STATIC_BANDS.index(b) for b in LANDSCAN_BANDS],
+        "location": [STATIC_BANDS.index(b) for b in LOCATION_BANDS],
+        "DW_static": [STATIC_BANDS.index(b) for b in STATIC_DW_BANDS],
+        "WC_static": [STATIC_BANDS.index(b) for b in STATIC_WC_BANDS],
+    }
+)
+
+
+def get_2d_sincos_pos_embed_with_resolution(
+    embed_dim, grid_size, res, cls_token=False, device="cpu"
+):
+    """
+    grid_size: int of the grid height and width
+    res: array of size n, representing the resolution of a pixel (say, in meters),
+    return:
+    pos_embed: [n,grid_size*grid_size, embed_dim] or [n,1+grid_size*grid_size, embed_dim] (w/ or w/o cls_token)
+    """
+    res = res.to(device)
+    grid_h = torch.arange(grid_size, device=device)
+    grid_w = torch.arange(grid_size, device=device)
+    grid = torch.meshgrid(
+        grid_w, grid_h, indexing="xy"
+    )  # here h goes first,direction reversed for numpy
+    grid = torch.stack(grid, dim=0)  # 2 x h x w
+
+    # grid = grid.reshape([2, 1, grid_size, grid_size])
+    grid = torch.einsum("chw,n->cnhw", grid, res)  # 2 x n x h x w
+    _, n, h, w = grid.shape
+    pos_embed = get_2d_sincos_pos_embed_from_grid_torch(
+        embed_dim, grid
+    )  #  # (nxH*W, D/2)
+    pos_embed = pos_embed.reshape(n, h * w, embed_dim)
+    if cls_token:
+        pos_embed = torch.cat(
+            [
+                torch.zeros([n, 1, embed_dim], device=pos_embed.device),
+                pos_embed,
+            ],
+            dim=1,
+        )
+    return pos_embed
+
+
+def get_2d_sincos_pos_embed_from_grid_torch(embed_dim, grid):
+    assert embed_dim % 2 == 0
+
+    # use half of dimensions to encode grid_h
+    emb_h = get_1d_sincos_pos_embed_from_grid_torch(
+        embed_dim // 2, grid[0]
+    )  # (H*W, D/2)
+    emb_w = get_1d_sincos_pos_embed_from_grid_torch(
+        embed_dim // 2, grid[1]
+    )  # (H*W, D/2)
+
+    emb = torch.cat([emb_h, emb_w], dim=1)  # (H*W, D)
+    return emb
+
+
+def get_1d_sincos_pos_embed_from_grid_torch(embed_dim, pos):
+    """
+    embed_dim: output dimension for each position
+    pos: a list of positions to be encoded: size (M,)
+    out: (M, D)
+    """
+    assert embed_dim % 2 == 0
+    omega = torch.arange(embed_dim // 2, device=pos.device) / embed_dim / 2.0
+    omega = 1.0 / 10000**omega  # (D/2,)
+
+    pos = pos.reshape(-1)  # (M,)
+    out = torch.einsum("m,d->md", pos, omega)  # (M, D/2), outer product
+
+    emb_sin = torch.sin(out)  # (M, D/2)
+    emb_cos = torch.cos(out)  # (M, D/2)
+
+    emb = torch.cat([emb_sin, emb_cos], dim=1)  # (M, D)
+    return emb
+
+
+def get_month_encoding_table(embed_dim):
+    """Sinusoid month encoding table, for 12 months indexed from 0-11"""
+    assert embed_dim % 2 == 0
+    angles = torch.arange(0, 13) / (12 / (2 * np.pi))
+
+    sin_table = torch.sin(torch.stack([angles for _ in range(embed_dim // 2)], axis=-1))
+    cos_table = torch.cos(torch.stack([angles for _ in range(embed_dim // 2)], axis=-1))
+    month_table = torch.concatenate([sin_table[:-1], cos_table[:-1]], axis=-1)
+
+    return month_table  # (M, D)
+
+
+def adjust_learning_rate(
+    optimizer,
+    epoch,
+    warmup_epochs,
+    total_epochs,
+    max_lr,
+    min_lr,
+):
+    """Decay the learning rate with half-cycle cosine after warmup"""
+    if epoch < warmup_epochs:
+        lr = max_lr * epoch / warmup_epochs
+    else:
+        lr = min_lr + (max_lr - min_lr) * 0.5 * (
+            1.0
+            + math.cos(
+                math.pi * (epoch - warmup_epochs) / (total_epochs - warmup_epochs)
+            )
+        )
+    for group in optimizer.param_groups:
+        group["lr"] = lr
+    return lr
+
+
+# thanks to https://github.com/bwconrad/flexivit/ for this nice implementation
+# of the FlexiPatchEmbed module
+def to_2tuple(x: Any) -> Tuple:
+    if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
+        return tuple(x)
+    return tuple(itertools.repeat(x, 2))
+
+
+class FlexiPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size: Union[int, Tuple[int, int]],
+        in_chans: int = 3,
+        embed_dim: int = 128,
+        norm_layer: Optional[nn.Module] = None,
+        bias: bool = True,
+        patch_size_seq: Sequence[int] = (1, 2, 3, 4, 5, 6),
+        interpolation: str = "bicubic",
+        antialias: bool = True,
+    ) -> None:
+        """2D image to patch embedding w/ flexible patch sizes
+        Extended from: https://github.com/huggingface/pytorch-image-models/blob/main/timm/layers/patch_embed.py#L24
+        by https://github.com/bwconrad/flexivit/
+
+        Args:
+            patch_size: Base patch size. i.e the size of the parameter buffer
+            in_chans: Number of input image channels
+            embed_dim: Network embedding dimension size
+            norm_layer: Optional normalization layer
+            bias: Whether to use bias in convolution
+            patch_size_seq: List of patch sizes to randomly sample from
+            interpolation: Resize interpolation type
+            antialias: Whether to apply antialiasing resizing
+        """
+        super().__init__()
+
+        self.patch_size = to_2tuple(patch_size)
+
+        self.proj = nn.Conv2d(
+            in_chans,
+            embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            bias=bias,
+        )
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+        # Flexi specific attributes
+        self.interpolation = interpolation
+        self.antialias = antialias
+
+        self.patch_size_seq = patch_size_seq
+
+        # Pre-calculate pinvs
+        self.pinvs = self._cache_pinvs()
+
+    def _cache_pinvs(self) -> dict:
+        """Pre-calculate all pinv matrices"""
+        pinvs = {}
+        for ps in self.patch_size_seq:
+            tuple_ps = to_2tuple(ps)
+            pinvs[tuple_ps] = self._calculate_pinv(self.patch_size, tuple_ps)
+        return pinvs
+
+    def _resize(self, x: Tensor, shape: Tuple[int, int]) -> Tensor:
+        x_resized = F.interpolate(
+            x[None, None, ...],
+            shape,
+            mode=self.interpolation,
+            antialias=self.antialias,
+        )
+        return x_resized[0, 0, ...]
+
+    def _calculate_pinv(
+        self, old_shape: Tuple[int, int], new_shape: Tuple[int, int]
+    ) -> Tensor:
+        mat = []
+        for i in range(np.prod(old_shape)):
+            basis_vec = torch.zeros(old_shape)
+            basis_vec[np.unravel_index(i, old_shape)] = 1.0
+            mat.append(self._resize(basis_vec, new_shape).reshape(-1))
+        resize_matrix = torch.stack(mat)
+        return torch.linalg.pinv(resize_matrix)
+
+    def resize_patch_embed(self, patch_embed: Tensor, new_patch_size: Tuple[int, int]):
+        """Resize patch_embed to target resolution via pseudo-inverse resizing"""
+        # Return original kernel if no resize is necessary
+        if self.patch_size == new_patch_size:
+            return patch_embed
+
+        # Calculate pseudo-inverse of resize matrix
+        if new_patch_size not in self.pinvs:
+            self.pinvs[new_patch_size] = self._calculate_pinv(
+                self.patch_size, new_patch_size
+            )
+        pinv = self.pinvs[new_patch_size]
+        pinv = pinv.to(patch_embed.device)
+
+        def resample_patch_embed(patch_embed: Tensor):
+            h, w = new_patch_size
+            resampled_kernel = pinv @ patch_embed.reshape(-1)
+            return rearrange(resampled_kernel, "(h w) -> h w", h=h, w=w)
+
+        v_resample_patch_embed = vmap(vmap(resample_patch_embed, 0, 0), 1, 1)
+
+        return v_resample_patch_embed(patch_embed)
+
+    def forward(
+        self,
+        x: Tensor,
+        patch_size: Optional[Union[int, Tuple[int, int]]] = None,
+    ) -> Union[Tensor, Tuple[Tensor, Tuple[int, int]]]:
+        # x has input shape [b, h, w, (t), c]
+        batch_size = x.shape[0]
+        has_time_dimension = False
+        num_timesteps = 0  # ignored if has_time_dimension is False
+        if len(x.shape) == 5:
+            has_time_dimension = True
+            num_timesteps = x.shape[3]
+            x = rearrange(x, "b h w t c -> (b t) c h w")
+        else:
+            x = rearrange(x, "b h w c -> b c h w")
+
+        if not patch_size:
+            # During evaluation use base patch size if not specified
+            patch_size = self.patch_size
+
+        patch_size = to_2tuple(patch_size)
+
+        # Resize conv weights
+        if patch_size == self.patch_size:
+            weight = self.proj.weight
+        else:
+            weight = self.resize_patch_embed(self.proj.weight, patch_size)
+        # Apply conv with resized weights
+        x = F.conv2d(x, weight, bias=self.proj.bias, stride=patch_size)
+
+        if has_time_dimension:
+            x = rearrange(x, "(b t) c h w -> b h w t c", b=batch_size, t=num_timesteps)
+        else:
+            x = rearrange(x, "b c h w -> b h w c")
+        x = self.norm(x)
+
+        return x
+
+
+class Attention(nn.Module):
+    # https://github.com/huggingface/pytorch-image-models/blob/main/timm/models/vision_transformer.py
+    fast_attn: Final[bool]
+
+    def __init__(
+        self,
+        dim,
+        num_heads=8,
+        qkv_bias=False,
+        qk_norm=False,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        norm_layer=nn.LayerNorm,
+        cross_attn: bool = False,
+    ):
+        super().__init__()
+        assert dim % num_heads == 0, "dim should be divisible by num_heads"
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.fast_attn = hasattr(
+            torch.nn.functional, "scaled_dot_product_attention"
+        )  # FIXME
+
+        self.cross_attn = cross_attn
+
+        self.q = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k = nn.Linear(dim, dim, bias=qkv_bias)
+        self.v = nn.Linear(dim, dim, bias=qkv_bias)
+
+        self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x, y=None, attn_mask=None):
+        B, N, C = x.shape
+
+        q = self.q(x)
+
+        if y is None:
+            assert not self.cross_attn
+            k = self.k(x)
+            v = self.v(x)
+        else:
+            assert self.cross_attn
+            k = self.k(y)
+            v = self.v(y)
+
+        q = rearrange(q, "b n (h d) -> b h n d", h=self.num_heads)
+        k = rearrange(k, "b n (h d) -> b h n d", h=self.num_heads)
+        v = rearrange(v, "b n (h d) -> b h n d", h=self.num_heads)
+
+        q, k = self.q_norm(q), self.k_norm(k)
+        if self.fast_attn:
+            if attn_mask is not None:
+                attn_mask = attn_mask[:, None, None].repeat((1, self.num_heads, N, 1))
+            x = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                # a value of True indicates that the element should take part in attention
+                attn_mask=attn_mask,
+                dropout_p=self.attn_drop.p,
+            )
+        else:
+            if attn_mask is not None:
+                raise NotImplementedError
+            q = q * self.scale
+            attn = q @ k.transpose(-2, -1)
+            attn = attn.softmax(dim=-1)
+            attn = self.attn_drop(attn)
+            x = attn @ v
+
+        x = x.transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class Mlp(nn.Module):
+    """MLP as used in Vision Transformer, MLP-Mixer and related networks"""
+
+    def __init__(
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        bias=True,
+        drop=0.0,
+    ):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=bias)
+        self.act = act_layer()
+        self.drop1 = nn.Dropout(drop)
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=bias)
+        self.drop2 = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop1(x)
+        x = self.fc2(x)
+        x = self.drop2(x)
+        return x
+
+
+class LayerScale(nn.Module):
+    def __init__(self, dim, init_values=1e-5, inplace=False):
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(init_values * torch.ones(dim))
+
+    def forward(self, x):
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (
+        x.ndim - 1
+    )  # work with diff dim tensors, not just 2D ConvNets
+    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+    random_tensor.floor_()  # binarize
+    output = x.div(keep_prob) * random_tensor
+    return output
+
+
+class DropPath(nn.Module):
+    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+
+    def __init__(self, drop_prob=None):
+        super(DropPath, self).__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=False,
+        qk_norm=False,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        init_values=None,
+        act_layer=nn.GELU,
+        norm_layer=nn.LayerNorm,
+        cross_attn: bool = False,
+    ):
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+        self.attn = Attention(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            qk_norm=qk_norm,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+            norm_layer=norm_layer,
+            cross_attn=cross_attn,
+        )
+        self.ls1 = (
+            LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+        self.norm2 = norm_layer(dim)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=int(dim * mlp_ratio),
+            act_layer=act_layer,
+            drop=drop,
+        )
+        self.ls2 = (
+            LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+        )
+
+    def forward(self, x, y, attn_mask):
+        x = x + self.drop_path(self.ls1(self.attn(self.norm1(x), y, attn_mask)))
+        x = x + self.drop_path(self.ls2(self.mlp(self.norm2(x))))
+        return x
+
+
+class ModuleListWithInit(nn.ModuleList):
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            # we use xavier_uniform following official JAX ViT:
+            torch.nn.init.xavier_uniform_(m.weight)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+
+
+class GalileoBase(nn.Module):
+    cross_attn: bool
+
+    def __init__(
+        self,
+        embedding_size: int = 128,
+        depth=2,
+        mlp_ratio=2,
+        num_heads=8,
+        max_sequence_length=24,
+        base_patch_size: int = 4,
+        use_channel_embs: bool = True,
+        drop_path: float = 0.0,
+    ):
+        super().__init__()
+
+        self.space_time_groups = SPACE_TIME_BANDS_GROUPS_IDX
+        self.space_groups = SPACE_BAND_GROUPS_IDX
+        self.time_groups = TIME_BAND_GROUPS_IDX
+        self.static_groups = STATIC_BAND_GROUPS_IDX
+        self.embedding_size = embedding_size
+        self.base_patch_size = base_patch_size
+
+        self.blocks = ModuleListWithInit(
+            [
+                Block(
+                    embedding_size,
+                    num_heads,
+                    mlp_ratio,
+                    qkv_bias=True,
+                    norm_layer=nn.LayerNorm,
+                    cross_attn=self.cross_attn,
+                    drop_path=drop_path,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+        self.max_sequence_length = max_sequence_length
+        # we have 4 embeddings (pos_in_time, pos_in_space, month, channel) so each get
+        # 0.25 of the dimension. This will change soon anyway
+        self.pos_embed = nn.Parameter(
+            get_1d_sincos_pos_embed_from_grid_torch(
+                int(embedding_size * 0.25), torch.arange(max_sequence_length)
+            ),
+            requires_grad=False,
+        )
+        month_tab = get_month_encoding_table(int(embedding_size * 0.25))
+        self.month_embed = nn.Embedding.from_pretrained(month_tab, freeze=True)
+        if use_channel_embs:
+            args = {"requires_grad": True}
+        else:
+            args = {"requires_grad": False}
+        self.s_t_channel_embed = nn.Parameter(
+            torch.zeros(len(SPACE_TIME_BANDS_GROUPS_IDX), int(embedding_size * 0.25)),
+            **args,
+        )
+        self.sp_channel_embed = nn.Parameter(
+            torch.zeros(len(SPACE_BAND_GROUPS_IDX), int(embedding_size * 0.25)), **args
+        )
+        self.t_channel_embed = nn.Parameter(
+            torch.zeros(len(TIME_BAND_GROUPS_IDX), int(embedding_size * 0.25)), **args
+        )
+        self.st_channel_embed = nn.Parameter(
+            torch.zeros(len(STATIC_BAND_GROUPS_IDX), int(embedding_size * 0.25)), **args
+        )
+
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            # we use xavier_uniform following official JAX ViT:
+            torch.nn.init.xavier_uniform_(m.weight)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+
+    @classmethod
+    def collapse_and_combine_hwtc(
+        cls,
+        s_t_x: torch.Tensor,
+        sp_x: torch.Tensor,
+        t_x: torch.Tensor,
+        st_x: torch.Tensor,
+        s_t_m: torch.Tensor,
+        sp_m: torch.Tensor,
+        t_m: torch.Tensor,
+        st_m: torch.Tensor,
+    ):
+        s_t_x = rearrange(s_t_x, "b h w t c_g d -> b (h w t c_g) d")
+        sp_x = rearrange(sp_x, "b h w c_g d -> b (h w c_g) d")
+        t_x = rearrange(t_x, "b t c_g d -> b (t c_g) d")
+
+        s_t_m = rearrange(s_t_m, "b h w t c_g-> b (h w t c_g)")
+        sp_m = rearrange(sp_m, "b h w c_g-> b (h w c_g)")
+        t_m = rearrange(t_m, "b t c_g -> b (t c_g)")
+
+        x = torch.cat(
+            [
+                s_t_x,
+                sp_x,
+                t_x,
+                st_x,
+            ],
+            dim=1,
+        )
+        m = torch.cat([s_t_m, sp_m, t_m, st_m], dim=1)
+        return x, m
+
+    @classmethod
+    def split_and_expand_hwtc(
+        cls,
+        x: torch.Tensor,
+        h: int,
+        w: int,
+        t: int,
+        s_t_c_g: int,
+        sp_c_g: int,
+        t_c_g: int,
+        st_c_g: int,
+    ):
+        n_s_t_t = h * w * t * s_t_c_g
+        n_t_t = t * t_c_g
+
+        s_t_x = rearrange(
+            x[:, :n_s_t_t], "b (h w t c) d -> b h w t c d", h=h, w=w, t=t, c=s_t_c_g
+        )
+        sp_x = rearrange(
+            x[:, n_s_t_t : -(n_t_t + st_c_g)],
+            "b (h w c) d -> b h w c d",
+            h=h,
+            w=w,
+            c=sp_c_g,
+        )
+        t_x = rearrange(
+            x[:, -(n_t_t + st_c_g) : -st_c_g], "b (t c) d -> b t c d", t=t, c=t_c_g
+        )
+        st_x = x[:, -st_c_g:]
+
+        return s_t_x, sp_x, t_x, st_x
+
+    def apply_encodings(self, s_t_x, sp_x, t_x, st_x, months, patch_size, input_res):
+        b, h, w, t, s_t_c_g, _ = s_t_x.shape
+        sp_c_g, t_c_g = sp_x.shape[-2], t_x.shape[-2]
+        st_c_g = st_x.shape[-2]
+
+        s_t_channel = repeat(
+            self.s_t_channel_embed, "c_g d -> b h w t c_g d", b=b, h=h, w=w, t=t
+        )
+        t_channel = repeat(self.t_channel_embed, "c_g d -> b t c_g d", b=b, t=t)
+        st_channel = repeat(self.st_channel_embed, "c_g d -> b c_g d", b=b)
+        sp_channel = repeat(
+            self.sp_channel_embed, "c_g d -> b h w c_g d", b=b, h=h, w=w
+        )
+
+        pos_embed_s_t = repeat(
+            self.pos_embed[:t], "t d -> b h w t c_g d", b=b, h=h, w=w, c_g=s_t_c_g
+        )
+        m_embed_s_t = repeat(
+            self.month_embed(months), "b t d -> b h w t c_g d", h=h, w=w, c_g=s_t_c_g
+        )
+
+        pos_embed_t = repeat(self.pos_embed[:t], "t d -> b t c_g d", b=b, c_g=t_c_g)
+        m_embed_t = repeat(self.month_embed(months), "b t d -> b t c_g d", c_g=t_c_g)
+        t_zeros = torch.zeros(
+            b, t, t_c_g, int(self.embedding_size * 0.25), device=t_x.device
+        )
+
+        sp_zeros = torch.zeros(
+            b,
+            h,
+            w,
+            sp_c_g,
+            sp_channel.shape[-1] * 2,
+            device=sp_channel.device,
+        )
+
+        st_zeros = torch.zeros(
+            b, st_c_g, st_channel.shape[-1] * 3, device=st_channel.device
+        )
+
+        # find the resolution that each token represents, which will be
+        # the number of pixels in a patch * the resolution of each pixel
+        if patch_size is None:
+            patch_size = self.base_patch_size
+        token_res = input_res * patch_size
+        gsd_ratio = token_res / BASE_GSD
+
+        assert h == w, (
+            "get_2d_sincos_pos_embed_with_resolution currently requires that h==w"
+        )
+        spatial_embed = get_2d_sincos_pos_embed_with_resolution(
+            int(self.embedding_size * 0.25),
+            h,
+            torch.ones(b).to(s_t_x.device) * gsd_ratio,
+            device=s_t_x.device,
+        )
+        spatial_embed = rearrange(spatial_embed, "b (h w) d -> b h w d", h=h, w=w)
+        spatial_embed_s_t = repeat(
+            spatial_embed, "b h w d -> b h w t c_g d", h=h, w=w, t=t, c_g=s_t_c_g
+        )
+        spatial_embed_s = repeat(
+            spatial_embed, "b h w d -> b h w c_g d", h=h, w=w, c_g=sp_c_g
+        )
+
+        s_t_embed = torch.cat(
+            [s_t_channel, pos_embed_s_t, m_embed_s_t, spatial_embed_s_t], dim=-1
+        )
+        sp_embed = torch.cat([sp_channel, sp_zeros, spatial_embed_s], dim=-1)
+        t_embed = torch.cat([t_channel, pos_embed_t, m_embed_t, t_zeros], dim=-1)
+        st_embed = torch.cat([st_channel, st_zeros], dim=-1)
+        return s_t_x + s_t_embed, sp_x + sp_embed, t_x + t_embed, st_x + st_embed
+
+
+class Encoder(GalileoBase):
+    cross_attn = False
+
+    def __init__(
+        self,
+        max_patch_size: int = 8,
+        embedding_size: int = 128,
+        depth=2,
+        mlp_ratio=2,
+        num_heads=8,
+        max_sequence_length=24,
+        freeze_projections: bool = False,
+        drop_path: float = 0.0,
+    ):
+        super().__init__(
+            embedding_size,
+            depth,
+            mlp_ratio,
+            num_heads,
+            max_sequence_length,
+            max_patch_size,
+            use_channel_embs=True,
+            drop_path=drop_path,
+        )
+
+        self.space_time_embed = nn.ModuleDict(
+            {
+                group_name: FlexiPatchEmbed(
+                    in_chans=len(group),
+                    embed_dim=embedding_size,
+                    patch_size=max_patch_size,
+                )
+                for group_name, group in self.space_time_groups.items()
+            }
+        )
+        self.space_embed = nn.ModuleDict(
+            {
+                group_name: FlexiPatchEmbed(
+                    in_chans=len(group),
+                    embed_dim=embedding_size,
+                    patch_size=max_patch_size,
+                )
+                for group_name, group in self.space_groups.items()
+            }
+        )
+        self.time_embed = nn.ModuleDict(
+            {
+                group_name: nn.Linear(
+                    in_features=len(group), out_features=embedding_size
+                )
+                for group_name, group in self.time_groups.items()
+            }
+        )
+        self.static_embed = nn.ModuleDict(
+            {
+                group_name: nn.Linear(
+                    in_features=len(group), out_features=embedding_size
+                )
+                for group_name, group in self.static_groups.items()
+            }
+        )
+        if freeze_projections:
+            self.space_time_embed.requires_grad_(False)
+            self.space_embed.requires_grad_(False)
+            self.time_embed.requires_grad_(False)
+            self.static_embed.requires_grad_(False)
+        self.norm = nn.LayerNorm(embedding_size)
+
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            # we use xavier_uniform following official JAX ViT:
+            torch.nn.init.xavier_uniform_(m.weight)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+
+    def apply_linear_projection(
+        self,
+        s_t_x: torch.Tensor,
+        sp_x: torch.Tensor,
+        t_x: torch.Tensor,
+        st_x: torch.Tensor,
+        s_t_m: torch.Tensor,
+        sp_m: torch.Tensor,
+        t_m: torch.Tensor,
+        st_m: torch.Tensor,
+        patch_size: int,
+    ):
+        """
+        Given a [B, H, W, (T), C] inputs, returns a [B, H, W, (T), C_G, D] output.
+        We assume that the spatial masks are consistent for the given patch size,
+        so that if patch_size == 2 then one possible mask would be
+        [0, 0, 1, 1]
+        [0, 0, 1, 1]
+        [1, 1, 0, 0]
+        [1, 1, 0, 0]
+        for the H, W dimensions
+        """
+        b, h, w, t, _ = s_t_x.shape
+        new_h, new_w = h // patch_size, w // patch_size
+
+        s_t_l, sp_l, t_l, st_l, s_t_m_l, sp_m_l, t_m_l, st_m_l = (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
+        for idx, (channel_group, channel_idxs) in enumerate(
+            self.space_time_groups.items()
+        ):
+            s_t_m_l.append(s_t_m[:, 0::patch_size, 0::patch_size, :, idx])
+            if s_t_m_l[-1].min() == 0:
+                s_t_l.append(
+                    self.space_time_embed[channel_group](
+                        s_t_x[:, :, :, :, channel_idxs], patch_size=patch_size
+                    )
+                )
+            else:
+                s_t_l.append(
+                    torch.empty(
+                        b,
+                        new_h,
+                        new_w,
+                        t,
+                        self.embedding_size,
+                        dtype=s_t_x.dtype,
+                        device=s_t_x.device,
+                    )
+                )
+        for idx, (channel_group, channel_idxs) in enumerate(self.space_groups.items()):
+            sp_m_l.append(sp_m[:, 0::patch_size, 0::patch_size, idx])
+            if sp_m_l[-1].min() == 0:
+                sp_l.append(
+                    self.space_embed[channel_group](
+                        sp_x[:, :, :, channel_idxs], patch_size=patch_size
+                    )
+                )
+            else:
+                sp_l.append(
+                    torch.empty(
+                        b,
+                        new_h,
+                        new_w,
+                        self.embedding_size,
+                        dtype=sp_x.dtype,
+                        device=sp_x.device,
+                    )
+                )
+
+        for idx, (channel_group, channel_idxs) in enumerate(self.time_groups.items()):
+            t_m_l.append(t_m[:, :, idx])
+            if t_m_l[-1].min() == 0:
+                t_l.append(self.time_embed[channel_group](t_x[:, :, channel_idxs]))
+            else:
+                t_l.append(
+                    torch.empty(
+                        b, t, self.embedding_size, dtype=t_x.dtype, device=t_x.device
+                    )
+                )
+
+        for idx, (channel_group, channel_idxs) in enumerate(self.static_groups.items()):
+            st_m_l.append(st_m[:, idx])
+            if st_m_l[-1].min() == 0:
+                st_l.append(self.static_embed[channel_group](st_x[:, channel_idxs]))
+            else:
+                st_l.append(
+                    torch.empty(
+                        b, self.embedding_size, dtype=st_x.dtype, device=st_x.device
+                    )
+                )
+
+        return (
+            torch.stack(s_t_l, dim=-2),
+            torch.stack(sp_l, dim=-2),
+            torch.stack(t_l, dim=-2),
+            torch.stack(st_l, dim=-2),
+            torch.stack(s_t_m_l, dim=-1),
+            torch.stack(sp_m_l, dim=-1),
+            torch.stack(t_m_l, dim=-1),
+            torch.stack(st_m_l, dim=-1),
+        )
+
+    @staticmethod
+    def remove_masked_tokens(x, mask):
+        org_mask_dtype = mask.dtype
+        mask = mask.bool()
+        # https://stackoverflow.com/a/68621610/2332296
+        # move all non-masked values to the front of their rows
+        sorted_mask, indices = torch.sort(
+            (~mask).int(), dim=1, descending=True, stable=True
+        )
+        x = x.gather(1, indices[:, :, None].expand_as(x))
+        # set masked values to 0 (not really necessary since we'll ignore them anyway)
+        x = x * sorted_mask.unsqueeze(-1)
+
+        # cut off to the length of the longest sequence
+        max_length = sorted_mask.sum(-1).max()
+        x = x[:, :max_length]
+        updated_mask = 1 - sorted_mask[:, :max_length]
+
+        return x, indices, updated_mask.to(dtype=org_mask_dtype)
+
+    @staticmethod
+    def add_removed_tokens(x, indices, mask):
+        masked_tokens = repeat(
+            torch.zeros_like(x[0, 0, :]), "d -> b t d", b=x.shape[0], t=indices.shape[1]
+        )
+        full_mask = torch.cat(
+            (
+                mask,
+                torch.ones(
+                    (x.shape[0], indices.shape[1] - x.shape[1]),
+                    device=x.device,
+                    dtype=mask.dtype,
+                ),
+            ),
+            dim=-1,
+        )
+        # can't set value on leaf variable
+        out = masked_tokens.clone()
+        # put tokens in full masked tensor (at the first N positions in every row)
+        out[~full_mask.bool()] = x[~mask.bool()]
+        # then move them to their original positions
+        out = out.scatter(1, indices[:, :, None].expand_as(out), out)
+        full_mask = full_mask.scatter(1, indices.expand_as(full_mask), full_mask)
+        return out, full_mask
+
+    def apply_attn(
+        self,
+        s_t_x,
+        sp_x,
+        t_x,
+        st_x,
+        s_t_m,
+        sp_m,
+        t_m,
+        st_m,
+        months,
+        patch_size,
+        input_res,
+        exit_after,
+        token_exit_cfg,
+    ):
+        if token_exit_cfg:
+            exit_s_t, exit_sp, exit_t, exit_st = self.create_token_exit_ids(
+                s_t_x, sp_x, t_x, st_x, token_exit_cfg
+            )
+            exit_ids_seq, _ = self.collapse_and_combine_hwtc(
+                exit_s_t, exit_sp, exit_t, exit_st, s_t_m, sp_m, t_m, st_m
+            )
+            # exited_tokens starts as linear projections!
+            exited_tokens, _ = self.collapse_and_combine_hwtc(
+                s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+            )
+        else:
+            exit_ids_seq = None
+            exited_tokens = None
+
+        _, h, w, t, s_t_c_g, _ = s_t_x.shape
+        sp_c_g, t_c_g, st_c_g = sp_x.shape[3], t_x.shape[-2], st_x.shape[-2]
+        s_t_x, sp_x, t_x, st_x = self.apply_encodings(
+            s_t_x, sp_x, t_x, st_x, months, patch_size, input_res
+        )
+        x, m = self.collapse_and_combine_hwtc(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        )
+
+        # we only care about the values >= 1 for this mask, since 2 just tells the decoder
+        # to decode those tokens. From the perspective of the encoder, 1 and 2 are equivalent
+        # since they both represent masked values
+        new_m = m >= 1
+        x, indices, new_m = self.remove_masked_tokens(
+            x, new_m
+        )  # new_m is shape (bsz, seq_len)
+
+        if exit_ids_seq is not None:
+            exit_ids_seq, _, _ = self.remove_masked_tokens(exit_ids_seq, m >= 1)
+            # still linear projections
+            exited_tokens, _, _ = self.remove_masked_tokens(exited_tokens, m >= 1)
+
+        for i_blk, blk in enumerate(self.blocks):
+            if (exit_after is not None) and ((i_blk + 1) > exit_after):
+                # if exit_after is N, then we exit after the Nth layer
+                # if exit_after is 0, then all layers are skipped
+                break
+
+            # skip the 0th block since this is just the linear
+            # projection
+            if (exit_ids_seq is not None) and (i_blk > 0):
+                assert exited_tokens is not None
+                # half depth
+                exited_tokens = torch.where(
+                    condition=(exit_ids_seq == i_blk),
+                    input=x.detach(),
+                    other=exited_tokens.detach(),
+                )
+
+            # we take the inverse of the mask because a value
+            # of True indicates the value *should* take part in
+            # attention
+            x = blk(x=x, y=None, attn_mask=~new_m.bool())
+
+        if exit_ids_seq is not None:
+            assert exited_tokens is not None
+            # full depth
+            # IMPORTANT: write this to x
+            x = torch.where(
+                condition=(exit_ids_seq == (i_blk + 1)),  # 2 for full depth
+                input=x.detach(),
+                other=exited_tokens.detach(),
+            )
+
+        # we don't care about the mask returned by add_removed_tokens, since we will
+        # just use the original, unclipped mask here
+        x, _ = self.add_removed_tokens(x, indices, new_m)
+        return (
+            *self.split_and_expand_hwtc(x, h, w, t, s_t_c_g, sp_c_g, t_c_g, st_c_g),
+            s_t_m,
+            sp_m,
+            t_m,
+            st_m,
+        )
+
+    @classmethod
+    def average_tokens(cls, s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m):
+        x, m = cls.collapse_and_combine_hwtc(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        )
+        x, _, m = cls.remove_masked_tokens(x, m)
+        x_for_mean = x * (1 - m.unsqueeze(-1))
+        return x_for_mean.sum(dim=1) / torch.sum(1 - m, -1, keepdim=True)
+
+    @classmethod
+    def apply_mask_and_average_tokens_per_patch(
+        cls,
+        s_t_x: torch.Tensor,
+        sp_x: torch.Tensor,
+        t_x: torch.Tensor,
+        st_x: torch.Tensor,
+        s_t_m: torch.Tensor,
+        sp_m: torch.Tensor,
+        t_m: torch.Tensor,
+        st_m: torch.Tensor,
+    ):
+        s_t_x = rearrange(s_t_x, "b t_h t_w t c_g d -> b (t_h t_w) (t c_g) d")
+        sp_x = rearrange(sp_x, "b t_h t_w c_g d -> b (t_h t_w) c_g d")
+        # repeat time tokens over space
+        t_x = repeat(
+            rearrange(t_x, "b t c_g d -> b (t c_g) d"),
+            "b n d -> b s n d",
+            s=sp_x.shape[1],
+        )
+        st_x = repeat(st_x, "b c_g d -> b s c_g d", s=sp_x.shape[1])
+        s_t_m = rearrange(s_t_m, "b t_h t_w t c_g-> b (t_h t_w) (t c_g)")
+        sp_m = rearrange(sp_m, "b t_h t_w c_g-> b (t_h t_w) c_g")
+        t_m = repeat(
+            rearrange(t_m, "b t c_g -> b (t c_g)"), "b n -> b s n", s=sp_x.shape[1]
+        )
+        st_m = repeat(st_m, "b c_g -> b s c_g", s=sp_x.shape[1])
+
+        x = torch.cat([s_t_x, sp_x, t_x, st_x], dim=2)  # B, S, N, D
+        m = torch.cat([s_t_m, sp_m, t_m, st_m], dim=2)  # B, S, N
+
+        x_for_mean = x * (1 - m.unsqueeze(-1))
+
+        return x_for_mean.sum(dim=2) / torch.sum(1 - m, -1, keepdim=True)
+
+    def create_token_exit_ids(self, s_t_x, sp_x, t_x, st_x, token_exit_cfg):
+        exit_s_t = torch.zeros_like(s_t_x)
+        exit_sp = torch.zeros_like(sp_x)
+        exit_t = torch.zeros_like(t_x)
+        exit_st = torch.zeros_like(st_x)
+
+        for idx, (key, _) in enumerate(self.space_time_groups.items()):
+            exit_s_t[:, :, :, :, idx, :] = token_exit_cfg[key]
+
+        for idx, (key, _) in enumerate(self.space_groups.items()):
+            exit_sp[:, :, :, idx, :] = token_exit_cfg[key]
+
+        for idx, (key, _) in enumerate(self.time_groups.items()):
+            exit_t[:, :, idx, :] = token_exit_cfg[key]
+
+        for idx, (key, _) in enumerate(self.static_groups.items()):
+            exit_st[:, idx, :] = token_exit_cfg[key]
+        return exit_s_t, exit_sp, exit_t, exit_st
+
+    def forward(
+        self,
+        s_t_x: torch.Tensor,
+        sp_x: torch.Tensor,
+        t_x: torch.Tensor,
+        st_x: torch.Tensor,
+        s_t_m: torch.Tensor,
+        sp_m: torch.Tensor,
+        t_m: torch.Tensor,
+        st_m: torch.Tensor,
+        months: torch.Tensor,
+        patch_size: int,
+        input_resolution_m: Optional[int] = BASE_GSD,
+        exit_after: Optional[int] = None,
+        token_exit_cfg: Optional[Dict] = None,
+        add_layernorm_on_exit: bool = True,
+    ):
+        (
+            s_t_x,
+            sp_x,
+            t_x,
+            st_x,
+            s_t_m,
+            sp_m,
+            t_m,
+            st_m,
+        ) = self.apply_linear_projection(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m, patch_size
+        )
+
+        if (exit_after is None) or (exit_after > 0):
+            s_t_x, sp_x, t_x, st_x, s_t_m, st_m, t_m, st_m = self.apply_attn(
+                s_t_x,
+                sp_x,
+                t_x,
+                st_x,
+                s_t_m,
+                sp_m,
+                t_m,
+                st_m,
+                months,
+                patch_size,
+                input_resolution_m,
+                exit_after=exit_after,
+                token_exit_cfg=token_exit_cfg,
+            )
+
+        if add_layernorm_on_exit:
+            s_t_x = self.norm(s_t_x)
+            sp_x = self.norm(sp_x)
+            t_x = self.norm(t_x)
+            st_x = self.norm(st_x)
+        return (
+            s_t_x,
+            sp_x,
+            t_x,
+            st_x,
+            s_t_m,
+            sp_m,
+            t_m,
+            st_m,
+            months,
+        )
+
+    @classmethod
+    def load_from_folder(cls, folder: Path, device: torch.device):
+        if not (folder / CONFIG_FILENAME).exists():
+            all_files_in_folder = [f.name for f in folder.glob("*")]
+            raise ValueError(
+                f"Expected {CONFIG_FILENAME} in {folder}, found {all_files_in_folder}"
+            )
+        if not (folder / ENCODER_FILENAME).exists():
+            all_files_in_folder = [f.name for f in folder.glob("*")]
+            raise ValueError(
+                f"Expected {ENCODER_FILENAME} in {folder}, found {all_files_in_folder}"
+            )
+
+        with (folder / CONFIG_FILENAME).open("r") as f:
+            config = json.load(f)
+            model_config = config["model"]
+            encoder_config = model_config["encoder"]
+        encoder = cls(**encoder_config)
+
+        state_dict = torch.load(folder / ENCODER_FILENAME, map_location=device)
+        for key in list(state_dict.keys()):
+            # this cleans the state dict, which occasionally had an extra
+            # ".backbone" included in the key names
+            state_dict[key.replace(".backbone", "")] = state_dict.pop(key)
+        encoder.load_state_dict(state_dict)
+        return encoder
+
+
+class Decoder(GalileoBase):
+    cross_attn = True
+
+    def __init__(
+        self,
+        encoder_embedding_size: int = 128,
+        decoder_embedding_size: int = 128,
+        depth=2,
+        mlp_ratio=2,
+        num_heads=8,
+        max_sequence_length=24,
+        max_patch_size: int = 8,
+        learnable_channel_embeddings: bool = False,
+        output_embedding_size: Optional[int] = None,
+    ):
+        super().__init__(
+            decoder_embedding_size,
+            depth,
+            mlp_ratio,
+            num_heads,
+            max_sequence_length,
+            max_patch_size,
+            use_channel_embs=learnable_channel_embeddings,
+            drop_path=0.0,
+        )
+        self.learnable_channel_embeddings = learnable_channel_embeddings
+        self.encoder_embedding_size = encoder_embedding_size
+        self.encoder_to_decoder_embed = nn.Linear(
+            encoder_embedding_size, decoder_embedding_size, bias=True
+        )
+        if output_embedding_size is None:
+            output_embedding_size = encoder_embedding_size
+        self.output_embedding_size = output_embedding_size
+        self.to_output_embed = nn.Linear(
+            decoder_embedding_size, output_embedding_size, bias=True
+        )
+        self.mask_token = nn.Parameter(torch.zeros(decoder_embedding_size))
+
+        self.max_patch_size = max_patch_size
+        self.input_norm = nn.LayerNorm(encoder_embedding_size)
+        self.norm = nn.LayerNorm(decoder_embedding_size)
+        self.apply(self._init_weights)
+
+    def add_masks(self, s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m):
+        def to_kept_boolean(m: torch.Tensor):
+            # returns a mask where 1 indicates the value should be decoded
+            # (i.e. was 2) and 0 elsewhere
+            return (m == 2).to(dtype=m.dtype)
+
+        s_t_x = s_t_x * (1 - to_kept_boolean(s_t_m)).unsqueeze(-1)
+        B, H, W, T, S_T_C, _ = s_t_x.shape
+        s_t_m_reshaped = repeat(
+            self.mask_token, "d -> b h w t c d", b=B, h=H, w=W, t=T, c=S_T_C
+        )
+        s_t_m_add = s_t_m_reshaped * to_kept_boolean(s_t_m).unsqueeze(-1)
+
+        sp_x = sp_x * (1 - to_kept_boolean(sp_m)).unsqueeze(-1)
+        SP_C = sp_x.shape[-2]
+        sp_m_reshaped = repeat(self.mask_token, "d -> b h w c d", b=B, h=H, w=W, c=SP_C)
+        sp_m_add = sp_m_reshaped * to_kept_boolean(sp_m).unsqueeze(-1)
+
+        t_x = t_x * (1 - to_kept_boolean(t_m)).unsqueeze(-1)
+        T_C = t_x.shape[-2]
+        t_m_reshaped = repeat(self.mask_token, "d -> b t c d", b=B, t=T, c=T_C)
+        t_m_add = t_m_reshaped * to_kept_boolean(t_m).unsqueeze(-1)
+
+        st_x = st_x * (1 - to_kept_boolean(st_m)).unsqueeze(-1)
+        ST_C = st_x.shape[-2]
+        st_m_reshaped = repeat(self.mask_token, "d -> b c d", b=B, c=ST_C)
+        st_m_add = st_m_reshaped * to_kept_boolean(st_m).unsqueeze(-1)
+
+        return (
+            s_t_x + s_t_m_add,
+            sp_x + sp_m_add,
+            t_x + t_m_add,
+            st_x + st_m_add,
+        )
+
+    @staticmethod
+    def split_x_y(tokens, mask):
+        org_mask_dtype = mask.dtype
+        # https://stackoverflow.com/a/68621610/2332296
+        # move all non-masked values to the front of their rows
+        # and all masked values to be decoded to the end of their rows
+        # since we multiply by -1, we now have that -2: to be decoded, -1: masked and ignored, 0: unmasked
+        sorted_mask, indices = torch.sort(
+            mask.int(), dim=1, descending=True, stable=True
+        )
+        tokens = tokens.gather(1, indices[:, :, None].expand_as(tokens))
+        # cut off to the length of the longest sequence
+        max_length_to_be_decoded = (sorted_mask == 2).sum(-1).max()
+        max_length_of_unmasked_tokens = (sorted_mask == 0).sum(-1).max()
+        # x will be the query tokens, and y will be the key / value tokens
+        x = tokens[:, :max_length_to_be_decoded]
+        y = tokens[:, -max_length_of_unmasked_tokens:]
+
+        # the x_mask is just going to be used in the reconstruction, to know which
+        # x tokens to add back into the token list. TODO is this even necessary? it could
+        # get padded with noise tokens since we don't care about reconstruction at all
+        # for a whole bunch of tokens
+        x_mask = (sorted_mask == 2)[:, :max_length_to_be_decoded].to(
+            dtype=org_mask_dtype
+        )
+        # the y mask is going to be used to determine which of the y values take. True values
+        # take part in the attention (we don't take the inverse here, unlike in the decoder)
+        y_mask = (sorted_mask == 0)[:, -max_length_of_unmasked_tokens:].to(
+            dtype=org_mask_dtype
+        )
+        return x, y, x_mask, y_mask, indices
+
+    @staticmethod
+    def combine_x_y(x, y, x_mask, y_mask, indices):
+        # multiply by mask to zero out, then add
+        B, T = indices.shape[0], indices.shape[1]
+        D = x.shape[-1]
+        tokens = torch.zeros((B, T, D), dtype=x.dtype, device=x.device)
+        tokens[:, -y.shape[1] :] = y * y_mask.unsqueeze(-1)
+        tokens[:, : x.shape[1]] += x * x_mask.unsqueeze(-1)
+        tokens = tokens.scatter(1, indices[:, :, None].expand_as(tokens), tokens)
+        return tokens
+
+    def apply_attn(
+        self,
+        s_t_x,
+        sp_x,
+        t_x,
+        st_x,
+        s_t_m,
+        sp_m,
+        t_m,
+        st_m,
+        months,
+        patch_size,
+        input_res,
+    ):
+        _, h, w, t, s_t_c_g, _ = s_t_x.shape
+        sp_c_g, t_c_g, st_c_g = sp_x.shape[3], t_x.shape[-2], st_x.shape[-2]
+        s_t_x, sp_x, t_x, st_x = self.apply_encodings(
+            s_t_x, sp_x, t_x, st_x, months, patch_size, input_res
+        )
+        x, m = self.collapse_and_combine_hwtc(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        )
+        x, y, x_mask, y_mask, indices = self.split_x_y(x, m)
+        for blk in self.blocks:
+            # note that we are not taking the inverse of the mask, since split_x_y gives us
+            # true values for values we want to take part in attention
+            x = blk(x=x, y=y, attn_mask=y_mask.bool())
+        x = self.combine_x_y(x, y, x_mask, y_mask, indices)
+        return (
+            *self.split_and_expand_hwtc(x, h, w, t, s_t_c_g, sp_c_g, t_c_g, st_c_g),
+            s_t_m,
+            sp_m,
+            t_m,
+            st_m,
+        )
+
+    def forward(
+        self,
+        s_t_x: torch.Tensor,
+        sp_x: torch.Tensor,
+        t_x: torch.Tensor,
+        st_x: torch.Tensor,
+        s_t_m: torch.Tensor,
+        sp_m: torch.Tensor,
+        t_m: torch.Tensor,
+        st_m: torch.Tensor,
+        months: torch.Tensor,
+        patch_size: Optional[int] = None,
+        input_resolution_m: Optional[int] = BASE_GSD,
+    ):
+        s_t_x = self.encoder_to_decoder_embed(self.input_norm(s_t_x))
+        sp_x = self.encoder_to_decoder_embed(self.input_norm(sp_x))
+        t_x = self.encoder_to_decoder_embed(self.input_norm(t_x))
+        st_x = self.encoder_to_decoder_embed(self.input_norm(st_x))
+
+        s_t_x, sp_x, t_x, st_x = self.add_masks(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        )
+        s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m = self.apply_attn(
+            s_t_x,
+            sp_x,
+            t_x,
+            st_x,
+            s_t_m,
+            sp_m,
+            t_m,
+            st_m,
+            months,
+            patch_size,
+            input_resolution_m,
+        )
+
+        b, h, w, t, _, _ = s_t_x.shape
+        output_s_t, output_sp, output_t, output_st = [], [], [], []
+        for idx in range(len(self.space_time_groups)):
+            if s_t_m[:, :, :, :, idx].max() == 2:
+                output_s_t.append(
+                    self.to_output_embed(self.norm(s_t_x[:, :, :, :, idx]))
+                )
+            else:
+                output_s_t.append(
+                    torch.empty(
+                        b,
+                        h,
+                        w,
+                        t,
+                        self.output_embedding_size,
+                        dtype=s_t_x.dtype,
+                        device=s_t_x.device,
+                    )
+                )
+
+        for idx in range(len(self.space_groups)):
+            # decoded has shape [b, h, w, len(c_g) * patch_size ** 2]
+            if sp_m[:, :, :, idx].max() == 2:
+                output_sp.append(self.to_output_embed(self.norm(sp_x[:, :, :, idx])))
+            else:
+                output_sp.append(
+                    torch.empty(
+                        b,
+                        h,
+                        w,
+                        self.output_embedding_size,
+                        dtype=sp_x.dtype,
+                        device=sp_x.device,
+                    )
+                )
+
+        for idx in range(len(self.time_groups)):
+            if t_m[:, :, idx].max() == 2:
+                output_t.append(self.to_output_embed(self.norm(t_x[:, :, idx])))
+            else:
+                output_t.append(
+                    torch.empty(
+                        b,
+                        t,
+                        self.output_embedding_size,
+                        dtype=t_x.dtype,
+                        device=t_x.device,
+                    )
+                )
+
+        for idx in range(len(self.static_groups)):
+            if st_m[:, idx].max() == 2:
+                output_st.append(self.to_output_embed(self.norm(st_x[:, idx])))
+            else:
+                output_st.append(
+                    torch.empty(
+                        b,
+                        self.output_embedding_size,
+                        dtype=st_x.dtype,
+                        device=st_x.device,
+                    )
+                )
+
+        return (
+            torch.stack(output_s_t, dim=-2),  # shape = b h w t c_g, d
+            torch.stack(output_sp, dim=-2),
+            torch.stack(output_t, dim=-2),
+            torch.stack(output_st, dim=-2),
+        )

--- a/geofm_src/foundation_models/galileo/util.py
+++ b/geofm_src/foundation_models/galileo/util.py
@@ -1,0 +1,471 @@
+import torch
+from typing import Union, NamedTuple, List, OrderedDict as OrderedDictType
+from typing import Optional, cast
+from torch import Tensor
+from torch import nn
+
+from collections import OrderedDict
+import math
+import numpy as np
+from copy import deepcopy
+
+
+DEFAULT_MONTH = 5
+
+
+# band information
+S1_BANDS = ["VV", "VH"]
+S2_BANDS = [
+    "B2",
+    "B3",
+    "B4",
+    "B5",
+    "B6",
+    "B7",
+    "B8",
+    "B8A",
+    "B11",
+    "B12",
+]
+ERA5_BANDS = ["temperature_2m", "total_precipitation_sum"]
+TC_BANDS = ["def", "soil", "aet"]
+VIIRS_BANDS = ["avg_rad"]
+SRTM_BANDS = ["elevation", "slope"]
+DW_BANDS = [
+    "DW_water",
+    "DW_trees",
+    "DW_grass",
+    "DW_flooded_vegetation",
+    "DW_crops",
+    "DW_shrub_and_scrub",
+    "DW_built",
+    "DW_bare",
+    "DW_snow_and_ice",
+]
+WC_BANDS = [
+    "WC_temporarycrops",
+    "WC_maize",
+    "WC_wintercereals",
+    "WC_springcereals",
+    "WC_irrigation",
+]
+STATIC_DW_BANDS = [f"{x}_static" for x in DW_BANDS]
+STATIC_WC_BANDS = [f"{x}_static" for x in WC_BANDS]
+
+LANDSCAN_BANDS = ["b1"]
+LOCATION_BANDS = ["x", "y", "z"]
+
+SPACE_TIME_BANDS = S1_BANDS + S2_BANDS + ["NDVI"]
+TIME_BANDS = ERA5_BANDS + TC_BANDS + VIIRS_BANDS
+SPACE_BANDS = SRTM_BANDS + DW_BANDS + WC_BANDS
+STATIC_BANDS = LANDSCAN_BANDS + LOCATION_BANDS + STATIC_DW_BANDS + STATIC_WC_BANDS
+
+
+SPACE_TIME_BANDS_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "S1": [SPACE_TIME_BANDS.index(b) for b in S1_BANDS],
+        "S2_RGB": [SPACE_TIME_BANDS.index(b) for b in ["B2", "B3", "B4"]],
+        "S2_Red_Edge": [SPACE_TIME_BANDS.index(b) for b in ["B5", "B6", "B7"]],
+        "S2_NIR_10m": [SPACE_TIME_BANDS.index(b) for b in ["B8"]],
+        "S2_NIR_20m": [SPACE_TIME_BANDS.index(b) for b in ["B8A"]],
+        "S2_SWIR": [SPACE_TIME_BANDS.index(b) for b in ["B11", "B12"]],
+        "NDVI": [SPACE_TIME_BANDS.index("NDVI")],
+    }
+)
+
+TIME_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "ERA5": [TIME_BANDS.index(b) for b in ERA5_BANDS],
+        "TC": [TIME_BANDS.index(b) for b in TC_BANDS],
+        "VIIRS": [TIME_BANDS.index(b) for b in VIIRS_BANDS],
+    }
+)
+
+SPACE_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "SRTM": [SPACE_BANDS.index(b) for b in SRTM_BANDS],
+        "DW": [SPACE_BANDS.index(b) for b in DW_BANDS],
+        "WC": [SPACE_BANDS.index(b) for b in WC_BANDS],
+    }
+)
+
+STATIC_BAND_GROUPS_IDX: OrderedDictType[str, List[int]] = OrderedDict(
+    {
+        "LS": [STATIC_BANDS.index(b) for b in LANDSCAN_BANDS],
+        "location": [STATIC_BANDS.index(b) for b in LOCATION_BANDS],
+        "DW_static": [STATIC_BANDS.index(b) for b in STATIC_DW_BANDS],
+        "WC_static": [STATIC_BANDS.index(b) for b in STATIC_WC_BANDS],
+    }
+)
+
+
+def to_cartesian(
+    lat: Union[float, np.ndarray, torch.Tensor],
+    lon: Union[float, np.ndarray, torch.Tensor],
+) -> Union[np.ndarray, torch.Tensor]:
+    if isinstance(lat, float):
+        assert -90 <= lat <= 90, (
+            f"lat out of range ({lat}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon <= 180, (
+            f"lon out of range ({lon}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lon, float), f"Expected float got {type(lon)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x = math.cos(lat) * math.cos(lon)
+        y = math.cos(lat) * math.sin(lon)
+        z = math.sin(lat)
+        return np.array([x, y, z])
+    elif isinstance(lon, np.ndarray):
+        assert -90 <= lat.min(), (
+            f"lat out of range ({lat.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 90 >= lat.max(), (
+            f"lat out of range ({lat.max()}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon.min(), (
+            f"lon out of range ({lon.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 180 >= lon.max(), (
+            f"lon out of range ({lon.max()}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lat, np.ndarray), f"Expected np.ndarray got {type(lat)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x_np = np.cos(lat) * np.cos(lon)
+        y_np = np.cos(lat) * np.sin(lon)
+        z_np = np.sin(lat)
+        return np.stack([x_np, y_np, z_np], axis=-1)
+    elif isinstance(lon, torch.Tensor):
+        assert -90 <= lat.min(), (
+            f"lat out of range ({lat.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 90 >= lat.max(), (
+            f"lat out of range ({lat.max()}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon.min(), (
+            f"lon out of range ({lon.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 180 >= lon.max(), (
+            f"lon out of range ({lon.max()}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lat, torch.Tensor), f"Expected torch.Tensor got {type(lat)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x_t = torch.cos(lat) * torch.cos(lon)
+        y_t = torch.cos(lat) * torch.sin(lon)
+        z_t = torch.sin(lat)
+        return torch.stack([x_t, y_t, z_t], dim=-1)
+    else:
+        raise AssertionError(f"Unexpected input type {type(lon)}")
+
+
+class Normalizer:
+    # these are the bands we will replace with the 2*std computation
+    # if std = True
+    std_bands: dict[int, list] = {
+        len(SPACE_TIME_BANDS): [b for b in SPACE_TIME_BANDS if b != "NDVI"],
+        len(SPACE_BANDS): SRTM_BANDS,
+        len(TIME_BANDS): TIME_BANDS,
+        len(STATIC_BANDS): LANDSCAN_BANDS,
+    }
+
+    def __init__(
+        self,
+        std: bool = True,
+        normalizing_dicts: Optional[dict] = None,
+        std_multiplier: float = 2,
+    ):
+        self.shift_div_dict = {
+            len(SPACE_TIME_BANDS): {
+                "shift": deepcopy(SPACE_TIME_SHIFT_VALUES),
+                "div": deepcopy(SPACE_TIME_DIV_VALUES),
+            },
+            len(SPACE_BANDS): {
+                "shift": deepcopy(SPACE_SHIFT_VALUES),
+                "div": deepcopy(SPACE_DIV_VALUES),
+            },
+            len(TIME_BANDS): {
+                "shift": deepcopy(TIME_SHIFT_VALUES),
+                "div": deepcopy(TIME_DIV_VALUES),
+            },
+            len(STATIC_BANDS): {
+                "shift": deepcopy(STATIC_SHIFT_VALUES),
+                "div": deepcopy(STATIC_DIV_VALUES),
+            },
+        }
+        print(self.shift_div_dict.keys())
+        self.normalizing_dicts = normalizing_dicts
+        if std:
+            name_to_bands = {
+                len(SPACE_TIME_BANDS): SPACE_TIME_BANDS,
+                len(SPACE_BANDS): SPACE_BANDS,
+                len(TIME_BANDS): TIME_BANDS,
+                len(STATIC_BANDS): STATIC_BANDS,
+            }
+            assert normalizing_dicts is not None
+            for key, val in normalizing_dicts.items():
+                if isinstance(key, str):
+                    continue
+                bands_to_replace = self.std_bands[key]
+                for band in bands_to_replace:
+                    band_idx = name_to_bands[key].index(band)
+                    mean = val["mean"][band_idx]
+                    std = val["std"][band_idx]
+                    min_value = mean - (std_multiplier * std)
+                    max_value = mean + (std_multiplier * std)
+                    div = max_value - min_value
+                    if div == 0:
+                        raise ValueError(f"{band} has div value of 0")
+                    self.shift_div_dict[key]["shift"][band_idx] = min_value
+                    self.shift_div_dict[key]["div"][band_idx] = div
+
+    @staticmethod
+    def _normalize(
+        x: np.ndarray, shift_values: np.ndarray, div_values: np.ndarray
+    ) -> np.ndarray:
+        x = (x - shift_values) / div_values
+        return x
+
+    def __call__(self, x: np.ndarray):
+        div_values = self.shift_div_dict[x.shape[-1]]["div"]
+        return self._normalize(x, self.shift_div_dict[x.shape[-1]]["shift"], div_values)
+
+
+class MaskedOutput(NamedTuple):
+    """
+    A mask can take 3 values:
+    0: seen by the encoder (i.e. makes the key and value tokens in the decoder)
+    1: not seen by the encoder, and ignored by the decoder
+    2: not seen by the encoder, and processed by the decoder (the decoder's query values)
+    """
+
+    space_time_x: torch.Tensor  # [B, H, W, T, len(SPACE_TIME_BANDS)]
+    space_x: torch.Tensor  # [B, H, W, len(SPACE_BANDS)]
+    time_x: torch.Tensor  # [B, T, len(TIME_BANDS)]
+    static_x: torch.Tensor  # [B, len(STATIC_BANDS)]
+    space_time_mask: torch.Tensor  # [B, H, W, T, len(SPACE_TIME_BANDS_GROUPS_IDX)]
+    space_mask: torch.Tensor  # [B, H, W, len(SPACE_BAND_GROUPS_IDX)]
+    time_mask: torch.Tensor  # [B, T, len(TIME_BAND_GROUPS_IDX)]
+    static_mask: torch.Tensor  # [B, len(STATIC_BAND_GROUPS_IDX)]
+    months: torch.Tensor  # [B, T]
+
+
+def construct_galileo_input(
+    s1: torch.Tensor | None = None,  # [H, W, T, D]
+    s2: torch.Tensor | None = None,  # [H, W, T, D]
+    era5: torch.Tensor | None = None,  # [T, D]
+    tc: torch.Tensor | None = None,  # [T, D]
+    viirs: torch.Tensor | None = None,  # [T, D]
+    srtm: torch.Tensor | None = None,  # [H, W, D]
+    dw: torch.Tensor | None = None,  # [H, W, D]
+    wc: torch.Tensor | None = None,  # [H, W, D]
+    landscan: torch.Tensor | None = None,  # [D]
+    latlon: torch.Tensor | None = None,  # [D]
+    months: torch.Tensor | None = None,  # [T]
+    normalize: bool = False,
+):
+    space_time_inputs = [s1, s2]
+    time_inputs = [era5, tc, viirs]
+    space_inputs = [srtm, dw, wc]
+    static_inputs = [landscan, latlon]
+    devices = [
+        x.device
+        for x in space_time_inputs + time_inputs + space_inputs + static_inputs
+        if x is not None
+    ]
+
+    if len(devices) == 0:
+        raise ValueError("At least one input must be not None")
+    if not all(devices[0] == device for device in devices):
+        raise ValueError("Received tensors on multiple devices")
+    device = devices[0]
+
+    # first, check all the input shapes are consistent
+    timesteps_list = [x.shape[2] for x in space_time_inputs if x is not None] + [
+        x.shape[1] for x in time_inputs if x is not None
+    ]
+    height_list = [x.shape[0] for x in space_time_inputs if x is not None] + [
+        x.shape[0] for x in space_inputs if x is not None
+    ]
+    width_list = [x.shape[1] for x in space_time_inputs if x is not None] + [
+        x.shape[1] for x in space_inputs if x is not None
+    ]
+
+    if len(timesteps_list) > 0:
+        if not all(timesteps_list[0] == timestep for timestep in timesteps_list):
+            raise ValueError("Inconsistent number of timesteps per input")
+        t = timesteps_list[0]
+    else:
+        t = 1
+
+    if len(height_list) > 0:
+        if not all(height_list[0] == height for height in height_list):
+            raise ValueError("Inconsistent heights per input")
+        if not all(width_list[0] == width for width in width_list):
+            raise ValueError("Inconsistent widths per input")
+        h = height_list[0]
+        w = width_list[0]
+    else:
+        h, w = 1, 1
+
+    # now, we can construct our empty input tensors. By default, everything is masked
+    s_t_x = torch.zeros(
+        (h, w, t, len(SPACE_TIME_BANDS)), dtype=torch.float, device=device
+    )
+    s_t_m = torch.ones(
+        (h, w, t, len(SPACE_TIME_BANDS_GROUPS_IDX)), dtype=torch.float, device=device
+    )
+    sp_x = torch.zeros((h, w, len(SPACE_BANDS)), dtype=torch.float, device=device)
+    sp_m = torch.ones(
+        (h, w, len(SPACE_BAND_GROUPS_IDX)), dtype=torch.float, device=device
+    )
+    t_x = torch.zeros((t, len(TIME_BANDS)), dtype=torch.float, device=device)
+    t_m = torch.ones((t, len(TIME_BAND_GROUPS_IDX)), dtype=torch.float, device=device)
+    st_x = torch.zeros((len(STATIC_BANDS)), dtype=torch.float, device=device)
+    st_m = torch.ones((len(STATIC_BAND_GROUPS_IDX)), dtype=torch.float, device=device)
+
+    for x, bands_list, group_key in zip([s1, s2], [S1_BANDS, S2_BANDS], ["S1", "S2"]):
+        if x is not None:
+            indices = [
+                idx for idx, val in enumerate(SPACE_TIME_BANDS) if val in bands_list
+            ]
+            groups_idx = [
+                idx
+                for idx, key in enumerate(SPACE_TIME_BANDS_GROUPS_IDX)
+                if group_key in key
+            ]
+            s_t_x[:, :, :, indices] = x
+            s_t_m[:, :, :, groups_idx] = 0
+
+    for x, bands_list, group_key in zip(
+        [srtm, dw, wc], [SRTM_BANDS, DW_BANDS, WC_BANDS], ["SRTM", "DW", "WC"]
+    ):
+        if x is not None:
+            indices = [idx for idx, val in enumerate(SPACE_BANDS) if val in bands_list]
+            groups_idx = [
+                idx for idx, key in enumerate(SPACE_BAND_GROUPS_IDX) if group_key in key
+            ]
+            sp_x[:, :, indices] = x
+            sp_m[:, :, groups_idx] = 0
+
+    for x, bands_list, group_key in zip(
+        [era5, tc, viirs], [ERA5_BANDS, TC_BANDS, VIIRS_BANDS], ["ERA5", "TC", "VIIRS"]
+    ):
+        if x is not None:
+            indices = [idx for idx, val in enumerate(TIME_BANDS) if val in bands_list]
+            groups_idx = [
+                idx for idx, key in enumerate(TIME_BAND_GROUPS_IDX) if group_key in key
+            ]
+            t_x[:, indices] = x
+            t_m[:, groups_idx] = 0
+
+    for x, bands_list, group_key in zip(
+        [landscan, latlon], [LANDSCAN_BANDS, LOCATION_BANDS], ["LS", "location"]
+    ):
+        if x is not None:
+            if group_key == "location":
+                # transform latlon to cartesian
+                x = cast(torch.Tensor, to_cartesian(x[0], x[1]))
+            indices = [idx for idx, val in enumerate(STATIC_BANDS) if val in bands_list]
+            groups_idx = [
+                idx
+                for idx, key in enumerate(STATIC_BAND_GROUPS_IDX)
+                if group_key in key
+            ]
+            st_x[indices] = x
+            st_m[groups_idx] = 0
+
+    if months is None:
+        months = torch.ones((t), dtype=torch.long, device=device) * DEFAULT_MONTH
+    else:
+        if months.shape[0] != t:
+            raise ValueError("Incorrect number of input months")
+
+    if normalize:
+        normalizer = Normalizer(std=False)
+        s_t_x = torch.from_numpy(normalizer(s_t_x.cpu().numpy())).to(device)
+        sp_x = torch.from_numpy(normalizer(sp_x.cpu().numpy())).to(device)
+        t_x = torch.from_numpy(normalizer(t_x.cpu().numpy())).to(device)
+        st_x = torch.from_numpy(normalizer(st_x.cpu().numpy())).to(device)
+
+    return MaskedOutput(
+        space_time_x=s_t_x,
+        space_time_mask=s_t_m,
+        space_x=sp_x,
+        space_mask=sp_m,
+        time_x=t_x,
+        time_mask=t_m,
+        static_x=st_x,
+        static_mask=st_m,
+        months=months,
+    )
+
+
+def to_cartesian(
+    lat: Union[float, np.ndarray, torch.Tensor],
+    lon: Union[float, np.ndarray, torch.Tensor],
+) -> Union[np.ndarray, torch.Tensor]:
+    if isinstance(lat, float):
+        assert -90 <= lat <= 90, (
+            f"lat out of range ({lat}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon <= 180, (
+            f"lon out of range ({lon}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lon, float), f"Expected float got {type(lon)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x = math.cos(lat) * math.cos(lon)
+        y = math.cos(lat) * math.sin(lon)
+        z = math.sin(lat)
+        return np.array([x, y, z])
+    elif isinstance(lon, np.ndarray):
+        assert -90 <= lat.min(), (
+            f"lat out of range ({lat.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 90 >= lat.max(), (
+            f"lat out of range ({lat.max()}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon.min(), (
+            f"lon out of range ({lon.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 180 >= lon.max(), (
+            f"lon out of range ({lon.max()}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lat, np.ndarray), f"Expected np.ndarray got {type(lat)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x_np = np.cos(lat) * np.cos(lon)
+        y_np = np.cos(lat) * np.sin(lon)
+        z_np = np.sin(lat)
+        return np.stack([x_np, y_np, z_np], axis=-1)
+    elif isinstance(lon, torch.Tensor):
+        assert -90 <= lat.min(), (
+            f"lat out of range ({lat.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 90 >= lat.max(), (
+            f"lat out of range ({lat.max()}). Make sure you are in EPSG:4326"
+        )
+        assert -180 <= lon.min(), (
+            f"lon out of range ({lon.min()}). Make sure you are in EPSG:4326"
+        )
+        assert 180 >= lon.max(), (
+            f"lon out of range ({lon.max()}). Make sure you are in EPSG:4326"
+        )
+        assert isinstance(lat, torch.Tensor), f"Expected torch.Tensor got {type(lat)}"
+        # transform to radians
+        lat = lat * math.pi / 180
+        lon = lon * math.pi / 180
+        x_t = torch.cos(lat) * torch.cos(lon)
+        y_t = torch.cos(lat) * torch.sin(lon)
+        z_t = torch.sin(lat)
+        return torch.stack([x_t, y_t, z_t], dim=-1)
+    else:
+        raise AssertionError(f"Unexpected input type {type(lon)}")

--- a/geofm_src/foundation_models/galileo_wrapper.py
+++ b/geofm_src/foundation_models/galileo_wrapper.py
@@ -1,0 +1,185 @@
+import os
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from einops import rearrange
+from torchvision.datasets.utils import download_url
+
+from .lightning_task import LightningClsRegTask, LightningSegmentationTask
+from .galileo.model import Encoder
+from .galileo.util import (
+    construct_galileo_input,
+    MaskedOutput,
+    SPACE_TIME_BANDS_GROUPS_IDX,
+)
+
+
+EXPECTED_CHANNELS = {
+    "s2": 10,
+    "s1": 3,
+    "s1-asc": 2,
+    "spot": 3,
+}
+
+
+def format_input(x: Tensor, input_key: str) -> dict[str, Tensor]:
+    """Process the input tensor and stack per-sample outputs to form a single MaskedOutput.
+
+    Args:
+        x (Tensor): Input tensor of shape [B, C, H, W] (for s1, s1-asc, or s2/spot).
+        input_key (str): Specifies how to interpret the channels.
+
+    Returns:
+        dict[str, Tensor]: A dictionary mapping names as expected by the encoder.
+    """
+    # Validate expected channel count.
+    expected = EXPECTED_CHANNELS.get(input_key)
+    if expected is None:
+        raise ValueError(f"Unsupported input key: {input_key}")
+    assert x.shape[1] == expected, (
+        f"Input tensor for {input_key} should have {expected} channels"
+    )
+
+    # For keys that require a time dimension unsqueeze and rearrange.
+    if input_key in {"s1", "s1-asc", "s2"}:
+        x = x.unsqueeze(1)  # Now shape: [B, 1, C, H, W]
+        x = rearrange(x, "B T C H W -> B H W T C")
+
+    # Process each element in the batch through the Galileo input function, but perhaps also need
+    # batched_collate_fn?
+    outputs = [construct_galileo_input(**{input_key: x[i]}) for i in range(x.shape[0])]
+
+    # Stack each field of the MaskedOutput over the batch dimension for batched input.
+    batched = MaskedOutput(
+        space_time_x=torch.stack([o.space_time_x for o in outputs], dim=0),
+        space_x=torch.stack([o.space_x for o in outputs], dim=0),
+        time_x=torch.stack([o.time_x for o in outputs], dim=0),
+        static_x=torch.stack([o.static_x for o in outputs], dim=0),
+        space_time_mask=torch.stack([o.space_time_mask for o in outputs], dim=0),
+        space_mask=torch.stack([o.space_mask for o in outputs], dim=0),
+        time_mask=torch.stack([o.time_mask for o in outputs], dim=0),
+        static_mask=torch.stack([o.static_mask for o in outputs], dim=0),
+        months=torch.stack([o.months for o in outputs], dim=0),
+    )
+
+    return {
+        "s_t_x": batched.space_time_x,
+        "sp_x": batched.space_x,
+        "t_x": batched.time_x,
+        "st_x": batched.static_x,
+        "s_t_m": batched.space_time_mask,
+        "sp_m": batched.space_mask,
+        "t_m": batched.time_mask,
+        "st_m": batched.static_mask,
+        "months": batched.months,
+    }
+
+
+def load_encoder(model_config):
+    URL = "https://hf.co/nasaharvest/galileo/resolve/main/models/base/{}"
+    pretrained_path = model_config.get("pretrained_path", None)
+    print(f"PRETRAINED PATH: {pretrained_path}")
+
+    if pretrained_path and not os.path.exists(pretrained_path):
+        # Download weights and config if they don't exist.
+        download_url(
+            URL.format("encoder.pt"),
+            os.path.dirname(pretrained_path),
+            filename=os.path.basename(pretrained_path),
+        )
+        download_url(
+            URL.format("config.json"),
+            os.path.dirname(pretrained_path),
+            filename="config.json",
+        )
+    path = pretrained_path if pretrained_path else None
+
+    encoder = Encoder.load_from_folder(Path(os.path.dirname(path)), device="cpu")
+    return encoder
+
+
+class GalileoClsReg(LightningClsRegTask):
+    def __init__(self, args, model_config, data_config):
+        """Initalizes the GalileoClsReg model.
+
+        Args:
+            args: Command-line arguments or similar.
+            model_config (Dict[str, Any]): Configuration for the model.
+            data_config (Dict[str, Any]): Configuration for the data.
+        """
+        super().__init__(args, model_config, data_config)
+        self.encoder = load_encoder(model_config)
+        self.linear_classifier = nn.Linear(
+            model_config.embed_dim, data_config.num_classes
+        )
+        self.dot_str_of_linear_classifier = None
+        self.freeze_and_return_params()
+        self.patch_size = model_config.patch_size
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass through the encoder and linear classifier.
+
+        Args:
+            x (Tensor): Input tensor.
+
+        Returns:
+            Tensor: Class predictions or regression outputs.
+        """
+        x = format_input(x, self.data_config.input_key)
+        if self.training_mode == "linear_probe":
+            with torch.no_grad():
+                outputs = self.encoder(patch_size=self.patch_size, **x)
+        else:
+            outputs = self.encoder(patch_size=self.patch_size, **x)
+
+        # Unpack outputs from encoder
+        s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m, months = outputs
+
+        # Average tokens to derive features based on
+        # https://github.com/nasaharvest/galileo/blob/e0581f735763fa5752b1d07b378384a3f28ca697/src/galileo.py#L1409
+        feat = self.encoder.average_tokens(
+            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        )
+        x = self.linear_classifier(feat)
+        return x
+
+
+class GalileoSegmentation(LightningSegmentationTask):
+    def __init__(self, args, model_config, data_config):
+        super().__init__(args, model_config, data_config)
+
+        self.encoder = load_encoder(model_config)
+
+        self._build_default_segm_modules()
+        self.freeze_and_return_params()
+
+    def _forward_feats(self, x: Tensor) -> Tensor:
+        """Forward pass to get features from the encoder.
+
+        Args:
+            x (Tensor): input tensor
+
+        Returns:
+            Tensor: features from the model
+        """
+        x = format_input(x, self.data_config.input_key)
+        feats = self.encoder(
+            samples,
+            patch_size=10,
+            output="dense",
+            output_modality=self.data_config.input_key,
+        )
+        return feats
+
+
+# Model factory for different dinov2 tasks
+def GalileoModel(args, model_config, data_config):
+    task = data_config.task
+    if task in ["classification", "regression"]:
+        return GalileoClsReg(args, model_config, data_config)
+    elif task == "segmentation":
+        return GalileoSegmentation(args, model_config, data_config)
+    else:
+        raise NotImplementedError("Task not supported")

--- a/geofm_src/main.py
+++ b/geofm_src/main.py
@@ -32,28 +32,37 @@ def print_trainable_parameters(model):
 
 @hydra.main(config_path="configs", config_name="config")
 def main(cfg: DictConfig):
-    is_fastdevrun = cfg.trainer.get('fast_dev_run', False)
+    is_fastdevrun = cfg.trainer.get("fast_dev_run", False)
 
     # setup output dir
     if cfg.output_dir is None:
         experiment_name = f"{cfg.model.model_type}/{cfg.model.training_mode}/{cfg.dataset.dataset_name}"
         args_defining_run = {
-            'lr': 'lr',
-            'batch_size': 'bsz',
-            'epochs': 'e',}
-        assert all([not '.' in k for k in args_defining_run.keys()]), "cannot contain nested '.' yet"
-        run_name = '_'.join([f"{v}={cfg[k]}" for k,v in args_defining_run.items()])
+            "lr": "lr",
+            "batch_size": "bsz",
+            "epochs": "e",
+        }
+        assert all([not "." in k for k in args_defining_run.keys()]), (
+            "cannot contain nested '.' yet"
+        )
+        run_name = "_".join([f"{v}={cfg[k]}" for k, v in args_defining_run.items()])
 
-        suff = cfg.output_dir_suffix if cfg.output_dir_suffix is not None else ''
-        cfg.output_dir = os.path.join(os.environ['ODIR'], experiment_name, suff, run_name)
+        suff = cfg.output_dir_suffix if cfg.output_dir_suffix is not None else ""
+        cfg.output_dir = os.path.join(
+            os.environ["ODIR"], experiment_name, suff, run_name
+        )
 
     else:
-        assert cfg.output_dir_suffix is None, "output_dir_suffix is only used when output_dir is not set"
+        assert cfg.output_dir_suffix is None, (
+            "output_dir_suffix is only used when output_dir is not set"
+        )
         experiment_name = os.path.basename(os.path.normpath(cfg.output_dir))
-        run_name = f"{experiment_name}_run_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        run_name = (
+            f"{experiment_name}_run_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
 
     # check if task already executed
-    if os.path.exists(os.path.join(cfg.output_dir, 'results.csv')):
+    if os.path.exists(os.path.join(cfg.output_dir, "results.csv")):
         if cfg.overwrite:
             print(f"Overwriting existing output dir: {cfg.output_dir}")
         else:
@@ -70,19 +79,18 @@ def main(cfg: DictConfig):
 
     # print & save config
     Path(cfg.output_dir).mkdir(parents=True, exist_ok=True)
-    OmegaConf.save(cfg, os.path.join(cfg.output_dir, 'config.yaml'))
+    OmegaConf.save(cfg, os.path.join(cfg.output_dir, "config.yaml"))
     print(OmegaConf.to_yaml(cfg))
-
 
     # Setup logger
     if cfg.logger == "mlflow":
         logger = MLFlowLogger(
             experiment_name=experiment_name,
             run_name=run_name,
-            tracking_uri=f"file:{os.path.join(os.environ['ODIR'], '_mlruns')}",)
-    elif cfg.logger == 'wandb':
+            tracking_uri=f"file:{os.path.join(os.environ['ODIR'], '_mlruns')}",
+        )
+    elif cfg.logger == "wandb":
         raise NotImplementedError()
-
 
     # Callbacks
     model_monitor = "val_miou" if task == "segmentation" else "val_acc1"
@@ -99,36 +107,38 @@ def main(cfg: DictConfig):
 
     # Initialize trainer
 
-    if cfg.num_gpus == 0: # cpu
+    if cfg.num_gpus == 0:  # cpu
         trainer = Trainer(
             logger=logger,
             callbacks=callbacks,
-            accelerator='cpu',
+            accelerator="cpu",
             max_epochs=cfg.epochs,
             num_sanity_val_steps=0,
-            **cfg.trainer)
+            **cfg.trainer,
+        )
 
-    elif cfg.num_gpus == 1: # single gpu
+    elif cfg.num_gpus == 1:  # single gpu
         trainer = Trainer(
             logger=logger,
             callbacks=callbacks,
-            accelerator='gpu',
+            accelerator="gpu",
             devices=cfg.num_gpus,
             max_epochs=cfg.epochs,
             num_sanity_val_steps=0,
-            **cfg.trainer)
+            **cfg.trainer,
+        )
 
-    else: # ddp on multiple gpus
+    else:  # ddp on multiple gpus
         trainer = Trainer(
             logger=logger,
             callbacks=callbacks,
-            accelerator='gpu',
+            accelerator="gpu",
             strategy=DDPStrategy(find_unused_parameters=False),
             devices=cfg.num_gpus,
             max_epochs=cfg.epochs,
             num_sanity_val_steps=0,
-            **cfg.trainer)
-        
+            **cfg.trainer,
+        )
 
     # Initialize data module
     cfg.dataset.image_resolution = cfg.model.image_resolution
@@ -137,7 +147,7 @@ def main(cfg: DictConfig):
         batch_size=cfg.batch_size,
         num_workers=cfg.num_workers,
         pin_memory=cfg.pin_mem,
-        seed = cfg.seed,
+        seed=cfg.seed,
     )
 
     # Create model (assumed to be a LightningModule)
@@ -148,17 +158,18 @@ def main(cfg: DictConfig):
     trainer.fit(model, data_module, ckpt_path=cfg.resume if cfg.resume else None)
 
     if is_fastdevrun:
-        print('No eval for fastdevrun.')
+        print("No eval for fastdevrun.")
         return
 
     # Test
     best_checkpoint_path = callbacks[0].best_model_path
     results_list = trainer.test(model, data_module, ckpt_path=best_checkpoint_path)
-    results_dict = {k:v for l in results_list for k,v in l.items()}
+    results_dict = {k: v for l in results_list for k, v in l.items()}
     results = pd.DataFrame([results_dict])
 
     # save results
-    results.to_csv(os.path.join(cfg.output_dir, 'results.csv'), index=False)
+    results.to_csv(os.path.join(cfg.output_dir, "results.csv"), index=False)
+
 
 if __name__ == "__main__":
     os.environ["MODEL_WEIGHTS_DIR"] = os.getenv("MODEL_WEIGHTS_DIR", "./fm_weights")

--- a/scripts/galileo_pe_eurosat10_linear_probe.sh
+++ b/scripts/galileo_pe_eurosat10_linear_probe.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+echo "Contents of the current directory:"
+ls -lah
+
+export CUDA_VISIBLE_DEVICES=0
+export GEO_BENCH_DIR=/mnt/data/cc_benchmark
+export MODEL_WEIGHTS_DIR=/mnt/data/fm_weights
+export PYTHONPATH="."
+export HYDRA_FULL_ERROR=1
+export ODIR="."
+
+
+model="galileo"
+dataset="geobench_eurosat_10b"
+
+training_mode=linear_probe
+params_to_train="[model.projector_s2.patch_embed.inconv.0.weight,\
+model.projector_s2.patch_embed.inconv.0.bias]"
+
+batch_size="64"
+task="classification"
+lr="0.002"
+epochs="30"
+warmup_epochs="3"
+pretrained_path=/mnt/data/fm_weights/galileo/encoder.pt
+
+num_gpus=$(echo $CUDA_VISIBLE_DEVICES | tr ',' '\n' | wc -l)
+
+/home/toolkit/.conda/envs/dofaEnv/bin/python geofm_src/main.py \
+output_dir=/mnt/results/nils/exps/${model}_${dataset} \
+training_mode=${training_mode} \
+dataset=${dataset} \
+batch_size=${batch_size} \
+model=${model} \
++model.training_mode=${training_mode} \
++model.params_to_train=${params_to_train} \
++model.pretrained_path=${pretrained_path} \
+dataset.input_key=s2 \
+dataset.image_resolution=128 \
+model.image_resolution=128 \
++model.patch_size=8 \
+\
+lr=${lr} \
+epochs=${epochs} \
+warmup_epochs=${warmup_epochs} \
+\
++task=${task} \
+num_workers=8 \
+seed=42 \
+num_gpus=${num_gpus} \
+dataset.data_path=${data_path} \
++trainer.fast_dev_run=True


### PR DESCRIPTION
This PR takes a stab add adding a wrapper for the Galileo Model. The most difficult (or what I am not sure about is the input construction) for the encoder.

Option 1 (currently implemented):
- Create an input batch to the galileo encoder by applying their suggested [utility function](https://github.com/nasaharvest/galileo/blob/e0581f735763fa5752b1d07b378384a3f28ca697/src/data/utils.py#L36)

Option 2:
- In the training script they use a collate function to create there input batch found [here](https://github.com/nasaharvest/galileo/blob/e0581f735763fa5752b1d07b378384a3f28ca697/src/collate_fns.py#L27)

I believe that the difference in the latter is that a different random masking strategy is applied every time. I am not sure what the performance effects are for finetuning via linear-probing or partial parameters.