### PR TITLE
Updated Galileo wrapper

### DIFF
--- a/geofm_src/configs/model/base/galileo.yaml
+++ b/geofm_src/configs/model/base/galileo.yaml
@@ -1,0 +1,13 @@
+model_type: galileo
+embed_dim: 768
+image_resolution: 224
+
+pretrained_path: ${oc.env:MODEL_WEIGHTS_DIR}/galileo/encoder.pt
+
+segm_blk_indices: [3, 5, 7, 11]
+accel_cls_blk_indices: [8, 9, 10, 11]
+default_cls_blk_indices: [11]
+
+input_key: s2
+
+patch_size: 8

--- a/geofm_src/factory.py
+++ b/geofm_src/factory.py
@@ -20,6 +20,7 @@ model_registry = {
     # "anysat": models.AnySatWrapper,
     "senpamae": models.SenPaMAEWrapper,
     "panopticon": models.PanopticonWrapper,
+    "galileo": models.GalileoWrapper,
 
     # "satmae": models.SatMAEWrapper,
     # "scalemae": models.ScaleMAEWrapper,

--- a/geofm_src/foundation_models/__init__.py
+++ b/geofm_src/foundation_models/__init__.py
@@ -7,5 +7,17 @@ from .softcon_wrapper import SoftConWrapper
 from .dofa_wrapper import DofaWrapper
 # from .satmae_wrapper import SatMAEWrapper
 # from .anysat_wrapper import AnySatWrapper  # type: ignore
+from .galileo_wrapper import GalileoWrapper
 from .senpamae_wrapper import SenPaMAEWrapper
 from .panopticon_wrapper import PanopticonWrapper
+
+__all__ = (
+    "PanopticonWrapper",
+    "CromaWrapper",
+    "DinoV2Wrapper",
+    "SoftConWrapper",
+    "DofaWrapper",
+    "GalileoWrapper",
+    "SenPaMAEWrapper",
+    "PanopticonWrapper",
+)

--- a/geofm_src/foundation_models/anysat_wrapper.py
+++ b/geofm_src/foundation_models/anysat_wrapper.py
@@ -1,56 +1,102 @@
 import torch.nn as nn
 import torch
+from torch import Tensor
+from einops import rearrange
+from geofm_src.foundation_models.galileo.util import construct_galileo_input, MaskedOutput
 
-from geofm_src.engine.lightning_task import LightningClsRegTask, LightningSegmentationTask
-
-
-
-def load_encoder():
-    encoder = torch.hub.load(
-        "gastruc/anysat", "anysat", pretrained=True, flash_attn=False)
-    return encoder
+from typing import Any
 
 
-class AnySatClsReg(LightningClsRegTask):
-    def __init__(self, args, model_config, data_config):
-        super().__init__(args, model_config, data_config)
+from geofm_src.engine.model import EvalModelWrapper
 
-        self.encoder = load_encoder()
 
-        self.linear_classifier = nn.Linear(
-            model_config.embed_dim, data_config.num_classes)
-        self.dot_str_of_linear_classifier = None
+EXPECTED_CHANNELS = {
+    "s2": 10,
+    "s1": 3,
+    "s1-asc": 2,
+    "spot": 3,
+}
 
-        self.freeze_and_return_params()
 
-    def forward(self, x):
-        x = {"spot": x}
-        x = self.encoder(
-            x, patch_size=16, output="tile", output_modality="spot")
-        x = self.linear_classifier(x)
+class AnySatWrapper(EvalModelWrapper):
+    def load_encoder(self, blk_indices):
+        self.encoder = torch.hub.load("gastruc/anysat", self.model_config.anysat_torchhub_id, pretrained=True, flash_attn=False)
+
+        # Dont think there is a norm layer to be used here
+        self.norm = nn.Identity()
+    
+        
+        # prepare hooks
+        for idx in blk_indices:
+            self.encoder.model.blocks[idx].register_forward_hook(
+                lambda m, i, o: self._cache_block(o))
+
+    def _cache_block(self,x):
+        self.cache.append(x)
+
+
+    def format_input(self, x: Tensor, input_key: str) -> dict[str, Tensor]:
+        """Process the input tensor and stack per-sample outputs to form a single MaskedOutput.
+
+        Args:
+            x (Tensor): Input tensor of shape [B, C, H, W] (for s1, s1-asc, or s2/spot).
+            input_key (str): Specifies how to interpret the channels.
+
+        Returns:
+            dict[str, Tensor]: A dictionary mapping names as expected by the encoder.
+        """
+        # Validate expected channel count.
+        expected = EXPECTED_CHANNELS.get(input_key)
+        if expected is None:
+            raise ValueError(f"Unsupported input key: {input_key}")
+        assert x.shape[1] == expected, (
+            f"Input tensor for {input_key} should have {expected} channels"
+        )
+
+        # For keys that require a time dimension unsqueeze and rearrange.
+        if input_key in {"s1", "s1-asc", "s2"}:
+            x = x.unsqueeze(1)  # Now shape: [B, 1, C, H, W]
+            x = rearrange(x, "B T C H W -> B H W T C")
+
+        # Process each element in the batch through the Galileo input function, but perhaps also need
+        # batched_collate_fn?
+        outputs = [construct_galileo_input(**{input_key: x[i]}) for i in range(x.shape[0])]
+
+        # Stack each field of the MaskedOutput over the batch dimension for batched input.
+        batched = MaskedOutput(
+            space_time_x=torch.stack([o.space_time_x for o in outputs], dim=0),
+            space_x=torch.stack([o.space_x for o in outputs], dim=0),
+            time_x=torch.stack([o.time_x for o in outputs], dim=0),
+            static_x=torch.stack([o.static_x for o in outputs], dim=0),
+            space_time_mask=torch.stack([o.space_time_mask for o in outputs], dim=0),
+            space_mask=torch.stack([o.space_mask for o in outputs], dim=0),
+            time_mask=torch.stack([o.time_mask for o in outputs], dim=0),
+            static_mask=torch.stack([o.static_mask for o in outputs], dim=0),
+            months=torch.stack([o.months for o in outputs], dim=0),
+        )
+
+        return {
+            "s_t_x": batched.space_time_x,
+            "sp_x": batched.space_x,
+            "t_x": batched.time_x,
+            "st_x": batched.static_x,
+            "s_t_m": batched.space_time_mask,
+            "sp_m": batched.space_mask,
+            "t_m": batched.time_mask,
+            "st_m": batched.static_mask,
+            "months": batched.months,
+        }
+
+    def get_blocks(self, x):
+        self.cache = []
+        # TODO these arguments will be different for segmentation 
+        self.encoder(self.format_input(x, self.model_config.input_key), patch_size=10, output='tile')
+        blocks = self.cache
+        self.cache = [] 
+        return blocks
+
+    def default_blocks_to_featurevec(self, block_list):
+        x = block_list[-1][:, 1:,:].mean(dim=1)
+        # TODO not sure how to configure the norm layer above
+        # x = self.norm(x)
         return x
-
-
-class AnySatSegmentation(LightningSegmentationTask):
-    def __init__(self, args, model_config, data_config):
-        super().__init__(args, model_config, data_config)
-
-        self.encoder = load_encoder()
-        self._build_default_segm_modules()
-        self.freeze_and_return_params()
-
-    def _forward_feats(self, samples):
-        feats = self.encoder(
-            samples, patch_size=16, output="dense", output_modality="aerial")
-        return feats
-
-
-# Model factory for different dinov2 tasks
-def AnySatModel(args, model_config, data_config):
-    task = data_config.task
-    if task in ["classification",'regression']:
-        return AnySatClsReg(args, model_config, data_config)
-    elif task == "segmentation":
-        return AnySatSegmentation(args, model_config, data_config)
-    else:
-        raise NotImplementedError("Task not supported")

--- a/geofm_src/foundation_models/anysat_wrapper.py
+++ b/geofm_src/foundation_models/anysat_wrapper.py
@@ -1,21 +1,12 @@
 import torch.nn as nn
 import torch
 from torch import Tensor
-from einops import rearrange
-from geofm_src.foundation_models.galileo.util import construct_galileo_input, MaskedOutput
-
+from einops import repeat
 from typing import Any
 
 
 from geofm_src.engine.model import EvalModelWrapper
 
-
-EXPECTED_CHANNELS = {
-    "s2": 10,
-    "s1": 3,
-    "s1-asc": 2,
-    "spot": 3,
-}
 
 
 class AnySatWrapper(EvalModelWrapper):
@@ -36,56 +27,43 @@ class AnySatWrapper(EvalModelWrapper):
 
 
     def format_input(self, x: Tensor, input_key: str) -> dict[str, Tensor]:
-        """Process the input tensor and stack per-sample outputs to form a single MaskedOutput.
-
+        """Format input tensor to be passed to the model.
+        
+        According to https://github.com/gastruc/AnySat?tab=readme-ov-file#format-your-data
         Args:
-            x (Tensor): Input tensor of shape [B, C, H, W] (for s1, s1-asc, or s2/spot).
-            input_key (str): Specifies how to interpret the channels.
-
+            x (Tensor): input tensor
         Returns:
-            dict[str, Tensor]: A dictionary mapping names as expected by the encoder.
+            dict[str, Tensor]: formatted input tensor
         """
-        # Validate expected channel count.
-        expected = EXPECTED_CHANNELS.get(input_key)
-        if expected is None:
-            raise ValueError(f"Unsupported input key: {input_key}")
-        assert x.shape[1] == expected, (
-            f"Input tensor for {input_key} should have {expected} channels"
-        )
+        match input_key:
+            case "s2":
+                assert x.shape[1] == 10, "Input tensor for s2 should have 10 channels"
+                # unsqueeze time dimension
+                x = x.unsqueeze(1)
+                dates = torch.arange(x.shape[1]).float()
 
-        # For keys that require a time dimension unsqueeze and rearrange.
-        if input_key in {"s1", "s1-asc", "s2"}:
-            x = x.unsqueeze(1)  # Now shape: [B, 1, C, H, W]
-            x = rearrange(x, "B T C H W -> B H W T C")
+            case "s1":
+                assert x.shape[1] == 3, "Input tensor for s1 should have 3 channels"
+                # unsqueeze time dimension
+                x = x.unsqueeze(1)
+                dates = torch.arange(x.shape[1]).float()
+            case "s1-asc":
+                assert x.shape[1] == 2, "Input tensor for s1-asc should have 2 channels"
+                # unsqueeze time dimension
+                x = x.unsqueeze(1)
+                dates = torch.arange(x.shape[1]).float()
 
-        # Process each element in the batch through the Galileo input function, but perhaps also need
-        # batched_collate_fn?
-        outputs = [construct_galileo_input(**{input_key: x[i]}) for i in range(x.shape[0])]
+            case "spot":
+                assert x.shape[1] == 3, "Input tensor for spot should have 3 channels"
+                dates = None
 
-        # Stack each field of the MaskedOutput over the batch dimension for batched input.
-        batched = MaskedOutput(
-            space_time_x=torch.stack([o.space_time_x for o in outputs], dim=0),
-            space_x=torch.stack([o.space_x for o in outputs], dim=0),
-            time_x=torch.stack([o.time_x for o in outputs], dim=0),
-            static_x=torch.stack([o.static_x for o in outputs], dim=0),
-            space_time_mask=torch.stack([o.space_time_mask for o in outputs], dim=0),
-            space_mask=torch.stack([o.space_mask for o in outputs], dim=0),
-            time_mask=torch.stack([o.time_mask for o in outputs], dim=0),
-            static_mask=torch.stack([o.static_mask for o in outputs], dim=0),
-            months=torch.stack([o.months for o in outputs], dim=0),
-        )
+        anysat_input = {input_key: x}
+        if dates is not None:
+            dates = repeat(dates, 't -> b t', b=x.shape[0])
+            anysat_input[f'{input_key}_dates'] = dates.to(x.device)
 
-        return {
-            "s_t_x": batched.space_time_x,
-            "sp_x": batched.space_x,
-            "t_x": batched.time_x,
-            "st_x": batched.static_x,
-            "s_t_m": batched.space_time_mask,
-            "sp_m": batched.space_mask,
-            "t_m": batched.time_mask,
-            "st_m": batched.static_mask,
-            "months": batched.months,
-        }
+
+        return anysat_input
 
     def get_blocks(self, x):
         self.cache = []
@@ -100,3 +78,4 @@ class AnySatWrapper(EvalModelWrapper):
         # TODO not sure how to configure the norm layer above
         # x = self.norm(x)
         return x
+

--- a/geofm_src/foundation_models/galileo_wrapper.py
+++ b/geofm_src/foundation_models/galileo_wrapper.py
@@ -6,6 +6,10 @@ from geofm_src.foundation_models.galileo.util import construct_galileo_input, Ma
 from .galileo.model import Encoder
 
 from typing import Any
+from pathlib import Path
+import os
+from torchvision.datasets.utils import download_url
+
 
 
 from geofm_src.engine.model import EvalModelWrapper
@@ -22,7 +26,7 @@ EXPECTED_CHANNELS = {
 class GalileoWrapper(EvalModelWrapper):
     def load_encoder(self, blk_indices):
         URL = "https://hf.co/nasaharvest/galileo/resolve/main/models/base/{}"
-        pretrained_path = model_config.get("pretrained_path", None)
+        pretrained_path = self.model_config.get("pretrained_path", None)
         print(f"PRETRAINED PATH: {pretrained_path}")
 
         if pretrained_path and not os.path.exists(pretrained_path):
@@ -40,18 +44,15 @@ class GalileoWrapper(EvalModelWrapper):
         path = pretrained_path if pretrained_path else None
 
         self.encoder = Encoder.load_from_folder(Path(os.path.dirname(path)), device="cpu")
-
-        print(self.encoder)
         
-
-        # Dont think there is a norm layer to be used here
-        self.norm = nn.Identity()
+        self.norm = self.encoder.norm
     
         
         # prepare hooks
         for idx in blk_indices:
-            self.encoder.model.blocks[idx].register_forward_hook(
+            self.encoder.blocks[idx].register_forward_hook(
                 lambda m, i, o: self._cache_block(o))
+
 
     def _cache_block(self,x):
         self.cache.append(x)
@@ -112,13 +113,12 @@ class GalileoWrapper(EvalModelWrapper):
     def get_blocks(self, x):
         self.cache = []
         # TODO these arguments will be different for segmentation 
-        self.encoder(patch_size=self.patch_size, **self.format_input(x, self.model_config.input_key))
+        self.encoder(patch_size=self.model_config.patch_size, **self.format_input(x, self.model_config.input_key))
         blocks = self.cache
         self.cache = [] 
         return blocks
 
     def default_blocks_to_featurevec(self, block_list):
         x = block_list[-1][:, 1:,:].mean(dim=1)
-        # TODO not sure how to configure the norm layer above
         x = self.norm(x)
         return x

--- a/geofm_src/foundation_models/galileo_wrapper.py
+++ b/geofm_src/foundation_models/galileo_wrapper.py
@@ -1,19 +1,14 @@
-import os
-from pathlib import Path
-
-import torch
 import torch.nn as nn
+import torch
 from torch import Tensor
 from einops import rearrange
-from torchvision.datasets.utils import download_url
-
-from .lightning_task import LightningClsRegTask, LightningSegmentationTask
+from geofm_src.foundation_models.galileo.util import construct_galileo_input, MaskedOutput
 from .galileo.model import Encoder
-from .galileo.util import (
-    construct_galileo_input,
-    MaskedOutput,
-    SPACE_TIME_BANDS_GROUPS_IDX,
-)
+
+from typing import Any
+
+
+from geofm_src.engine.model import EvalModelWrapper
 
 
 EXPECTED_CHANNELS = {
@@ -24,162 +19,106 @@ EXPECTED_CHANNELS = {
 }
 
 
-def format_input(x: Tensor, input_key: str) -> dict[str, Tensor]:
-    """Process the input tensor and stack per-sample outputs to form a single MaskedOutput.
+class GalileoWrapper(EvalModelWrapper):
+    def load_encoder(self, blk_indices):
+        URL = "https://hf.co/nasaharvest/galileo/resolve/main/models/base/{}"
+        pretrained_path = model_config.get("pretrained_path", None)
+        print(f"PRETRAINED PATH: {pretrained_path}")
 
-    Args:
-        x (Tensor): Input tensor of shape [B, C, H, W] (for s1, s1-asc, or s2/spot).
-        input_key (str): Specifies how to interpret the channels.
+        if pretrained_path and not os.path.exists(pretrained_path):
+            # Download weights and config if they don't exist.
+            download_url(
+                URL.format("encoder.pt"),
+                os.path.dirname(pretrained_path),
+                filename=os.path.basename(pretrained_path),
+            )
+            download_url(
+                URL.format("config.json"),
+                os.path.dirname(pretrained_path),
+                filename="config.json",
+            )
+        path = pretrained_path if pretrained_path else None
 
-    Returns:
-        dict[str, Tensor]: A dictionary mapping names as expected by the encoder.
-    """
-    # Validate expected channel count.
-    expected = EXPECTED_CHANNELS.get(input_key)
-    if expected is None:
-        raise ValueError(f"Unsupported input key: {input_key}")
-    assert x.shape[1] == expected, (
-        f"Input tensor for {input_key} should have {expected} channels"
-    )
+        self.encoder = Encoder.load_from_folder(Path(os.path.dirname(path)), device="cpu")
 
-    # For keys that require a time dimension unsqueeze and rearrange.
-    if input_key in {"s1", "s1-asc", "s2"}:
-        x = x.unsqueeze(1)  # Now shape: [B, 1, C, H, W]
-        x = rearrange(x, "B T C H W -> B H W T C")
+        print(self.encoder)
+        
 
-    # Process each element in the batch through the Galileo input function, but perhaps also need
-    # batched_collate_fn?
-    outputs = [construct_galileo_input(**{input_key: x[i]}) for i in range(x.shape[0])]
+        # Dont think there is a norm layer to be used here
+        self.norm = nn.Identity()
+    
+        
+        # prepare hooks
+        for idx in blk_indices:
+            self.encoder.model.blocks[idx].register_forward_hook(
+                lambda m, i, o: self._cache_block(o))
 
-    # Stack each field of the MaskedOutput over the batch dimension for batched input.
-    batched = MaskedOutput(
-        space_time_x=torch.stack([o.space_time_x for o in outputs], dim=0),
-        space_x=torch.stack([o.space_x for o in outputs], dim=0),
-        time_x=torch.stack([o.time_x for o in outputs], dim=0),
-        static_x=torch.stack([o.static_x for o in outputs], dim=0),
-        space_time_mask=torch.stack([o.space_time_mask for o in outputs], dim=0),
-        space_mask=torch.stack([o.space_mask for o in outputs], dim=0),
-        time_mask=torch.stack([o.time_mask for o in outputs], dim=0),
-        static_mask=torch.stack([o.static_mask for o in outputs], dim=0),
-        months=torch.stack([o.months for o in outputs], dim=0),
-    )
-
-    return {
-        "s_t_x": batched.space_time_x,
-        "sp_x": batched.space_x,
-        "t_x": batched.time_x,
-        "st_x": batched.static_x,
-        "s_t_m": batched.space_time_mask,
-        "sp_m": batched.space_mask,
-        "t_m": batched.time_mask,
-        "st_m": batched.static_mask,
-        "months": batched.months,
-    }
+    def _cache_block(self,x):
+        self.cache.append(x)
 
 
-def load_encoder(model_config):
-    URL = "https://hf.co/nasaharvest/galileo/resolve/main/models/base/{}"
-    pretrained_path = model_config.get("pretrained_path", None)
-    print(f"PRETRAINED PATH: {pretrained_path}")
-
-    if pretrained_path and not os.path.exists(pretrained_path):
-        # Download weights and config if they don't exist.
-        download_url(
-            URL.format("encoder.pt"),
-            os.path.dirname(pretrained_path),
-            filename=os.path.basename(pretrained_path),
-        )
-        download_url(
-            URL.format("config.json"),
-            os.path.dirname(pretrained_path),
-            filename="config.json",
-        )
-    path = pretrained_path if pretrained_path else None
-
-    encoder = Encoder.load_from_folder(Path(os.path.dirname(path)), device="cpu")
-    return encoder
-
-
-class GalileoClsReg(LightningClsRegTask):
-    def __init__(self, args, model_config, data_config):
-        """Initalizes the GalileoClsReg model.
+    def format_input(self, x: Tensor, input_key: str) -> dict[str, Tensor]:
+        """Process the input tensor and stack per-sample outputs to form a single MaskedOutput.
 
         Args:
-            args: Command-line arguments or similar.
-            model_config (Dict[str, Any]): Configuration for the model.
-            data_config (Dict[str, Any]): Configuration for the data.
-        """
-        super().__init__(args, model_config, data_config)
-        self.encoder = load_encoder(model_config)
-        self.linear_classifier = nn.Linear(
-            model_config.embed_dim, data_config.num_classes
-        )
-        self.dot_str_of_linear_classifier = None
-        self.freeze_and_return_params()
-        self.patch_size = model_config.patch_size
-
-    def forward(self, x: Tensor) -> Tensor:
-        """Forward pass through the encoder and linear classifier.
-
-        Args:
-            x (Tensor): Input tensor.
+            x (Tensor): Input tensor of shape [B, C, H, W] (for s1, s1-asc, or s2/spot).
+            input_key (str): Specifies how to interpret the channels.
 
         Returns:
-            Tensor: Class predictions or regression outputs.
+            dict[str, Tensor]: A dictionary mapping names as expected by the encoder.
         """
-        x = format_input(x, self.data_config.input_key)
-        if self.training_mode == "linear_probe":
-            with torch.no_grad():
-                outputs = self.encoder(patch_size=self.patch_size, **x)
-        else:
-            outputs = self.encoder(patch_size=self.patch_size, **x)
-
-        # Unpack outputs from encoder
-        s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m, months = outputs
-
-        # Average tokens to derive features based on
-        # https://github.com/nasaharvest/galileo/blob/e0581f735763fa5752b1d07b378384a3f28ca697/src/galileo.py#L1409
-        feat = self.encoder.average_tokens(
-            s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
+        # Validate expected channel count.
+        expected = EXPECTED_CHANNELS.get(input_key)
+        if expected is None:
+            raise ValueError(f"Unsupported input key: {input_key}")
+        assert x.shape[1] == expected, (
+            f"Input tensor for {input_key} should have {expected} channels"
         )
-        x = self.linear_classifier(feat)
+
+        # For keys that require a time dimension unsqueeze and rearrange.
+        if input_key in {"s1", "s1-asc", "s2"}:
+            x = x.unsqueeze(1)  # Now shape: [B, 1, C, H, W]
+            x = rearrange(x, "B T C H W -> B H W T C")
+
+        # Process each element in the batch through the Galileo input function, but perhaps also need
+        # batched_collate_fn?
+        outputs = [construct_galileo_input(**{input_key: x[i]}) for i in range(x.shape[0])]
+
+        # Stack each field of the MaskedOutput over the batch dimension for batched input.
+        batched = MaskedOutput(
+            space_time_x=torch.stack([o.space_time_x for o in outputs], dim=0),
+            space_x=torch.stack([o.space_x for o in outputs], dim=0),
+            time_x=torch.stack([o.time_x for o in outputs], dim=0),
+            static_x=torch.stack([o.static_x for o in outputs], dim=0),
+            space_time_mask=torch.stack([o.space_time_mask for o in outputs], dim=0),
+            space_mask=torch.stack([o.space_mask for o in outputs], dim=0),
+            time_mask=torch.stack([o.time_mask for o in outputs], dim=0),
+            static_mask=torch.stack([o.static_mask for o in outputs], dim=0),
+            months=torch.stack([o.months for o in outputs], dim=0),
+        )
+
+        return {
+            "s_t_x": batched.space_time_x,
+            "sp_x": batched.space_x,
+            "t_x": batched.time_x,
+            "st_x": batched.static_x,
+            "s_t_m": batched.space_time_mask,
+            "sp_m": batched.space_mask,
+            "t_m": batched.time_mask,
+            "st_m": batched.static_mask,
+            "months": batched.months,
+        }
+
+    def get_blocks(self, x):
+        self.cache = []
+        # TODO these arguments will be different for segmentation 
+        self.encoder(patch_size=self.patch_size, **self.format_input(x, self.model_config.input_key))
+        blocks = self.cache
+        self.cache = [] 
+        return blocks
+
+    def default_blocks_to_featurevec(self, block_list):
+        x = block_list[-1][:, 1:,:].mean(dim=1)
+        # TODO not sure how to configure the norm layer above
+        x = self.norm(x)
         return x
-
-
-class GalileoSegmentation(LightningSegmentationTask):
-    def __init__(self, args, model_config, data_config):
-        super().__init__(args, model_config, data_config)
-
-        self.encoder = load_encoder(model_config)
-
-        self._build_default_segm_modules()
-        self.freeze_and_return_params()
-
-    def _forward_feats(self, x: Tensor) -> Tensor:
-        """Forward pass to get features from the encoder.
-
-        Args:
-            x (Tensor): input tensor
-
-        Returns:
-            Tensor: features from the model
-        """
-        x = format_input(x, self.data_config.input_key)
-        feats = self.encoder(
-            samples,
-            patch_size=10,
-            output="dense",
-            output_modality=self.data_config.input_key,
-        )
-        return feats
-
-
-# Model factory for different dinov2 tasks
-def GalileoModel(args, model_config, data_config):
-    task = data_config.task
-    if task in ["classification", "regression"]:
-        return GalileoClsReg(args, model_config, data_config)
-    elif task == "segmentation":
-        return GalileoSegmentation(args, model_config, data_config)
-    else:
-        raise NotImplementedError("Task not supported")


### PR DESCRIPTION
Updated Galileo Wrapper, I am not sure whether any of this part is still needed somewhere, basically, how Galileo processes their feature tokens for a final feature vector @LeWaldm 

```python
# TODO: DO we need any of this part?
# Unpack outputs from encoder what we had in the old functionality?
s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m, months = outputs

# # Average tokens to derive features based on
# # https://github.com/nasaharvest/galileo/blob/e0581f735763fa5752b1d07b378384a3f28ca697/src/galileo.py#L1409
feat = self.encoder.average_tokens(
     s_t_x, sp_x, t_x, st_x, s_t_m, sp_m, t_m, st_m
 )
x = self.linear_classifier(feat)
return x
```
        